### PR TITLE
Add basic docs for adapters, refactors GithubAdapter

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -20,11 +20,11 @@ This translates to "an object with arbitrary string keys and arbitrary values". 
 
 Even though a repository object doesn't have a well-defined schema, Shepherd still needs to be able to derive information from repo objects, such as where a repository is checked out or how to format a repository object for printing. To accomplish this, adapters are required to have functions that allow Shepherd to query them for information about a specific repository.
 
-- `parseSelectedRepo(repo: string): IRepo`: When repositories are specified via the `--repos` option in the CLI, Shepherd needs to be able to turn those strings into an adapter's concept of a repository. This function accepts a string from the `--repos` option and turns it into a repo object. For example, the GitHub adapter would take the string `NerdWallet/shepherd` and return the object `{ owner: 'NerdWallet', name: 'shepherd' }`
+- `parseRepo(repo: string): IRepo`: When repositories are specified via the `--repos` option in the CLI, Shepherd needs to be able to turn those strings into an adapter's concept of a repository. This function accepts a string from the `--repos` option and turns it into a repo object. For example, the GitHub adapter would take the string `NerdWallet/shepherd` and return the object `{ owner: 'NerdWallet', name: 'shepherd' }`
+
+- `stringifyRepo(repo: IRepo): string;`: This function takes a repository object and should return a human-readable representation of it for use when printing status messages. For example, the GitHub adapter would take the object `{ owner: 'NerdWallet', name: 'shepherd' }` and return `NerdWallet/shepherd`. This should likely be the inverse of the `parseRepo` function, although Shepherd doesn't rely on that being the case.
 
 - `reposEqual(repo1: IRepo, repo2: IRepo): boolean`: This function takes two repository objects and indicates if they represent the same repository.
-
-- `formatRepo(repo: IRepo): string;`: This function takes a repository object and should return a human-readable representation of it for use when printing status messages. For example, the GitHub adapter would take the object `{ owner: 'NerdWallet', name: 'shepherd' }` and return `NerdWallet/shepherd`. This should essentially be the inverse of the `parseSelectedRepo` function.
 
 - `getRepoDir(repo: IRepo): string;`: This function takes a repository and returns the absolute path to the directory where this repo is checked out to.
 

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -7,11 +7,11 @@ export interface IRepo {
 interface IRepoAdapter {
   getCandidateRepos(): Promise<IRepo[]>;
 
-  parseSelectedRepo(repo: string): IRepo;
+  parseRepo(repo: string): IRepo;
 
   reposEqual(repo1: IRepo, repo2: IRepo): boolean;
 
-  formatRepo(repo: IRepo): string;
+  stringifyRepo(repo: IRepo): string;
 
   checkoutRepo(repo: IRepo): Promise<void>;
 

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -15,11 +15,11 @@ abstract class GitAdapter implements IRepoAdapter {
 
   public abstract getCandidateRepos(): Promise<IRepo[]>;
 
-  public abstract parseSelectedRepo(repo: string): IRepo;
+  public abstract parseRepo(repo: string): IRepo;
 
   public abstract reposEqual(repo1: IRepo, repo2: IRepo): boolean;
 
-  public abstract formatRepo(repo: IRepo): string;
+  public abstract stringifyRepo(repo: IRepo): string;
 
   public abstract getRepoDir(repo: IRepo): string;
 

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -40,10 +40,10 @@ class GithubAdapter extends GitAdapter {
     const searchResults = await paginateSearch(this.octokit, this.octokit.search.code)({
       q: this.migrationContext.migration.spec.search_query,
     });
-    return searchResults.map((r: any) => this.parseSelectedRepo(r.repository.full_name)).sort();
+    return searchResults.map((r: any) => this.parseRepo(r.repository.full_name)).sort();
   }
 
-  public parseSelectedRepo(repo: string): IRepo {
+  public parseRepo(repo: string): IRepo {
     const [owner, name] = repo.split('/');
     if (!owner || !name) {
       throw new Error(`Could not parse repo "${repo}"`);
@@ -55,7 +55,7 @@ class GithubAdapter extends GitAdapter {
     return isEqual(repo1, repo2);
   }
 
-  public formatRepo({ owner, name }: IRepo): string {
+  public stringifyRepo({ owner, name }: IRepo): string {
     return `${owner}/${name}`;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ const handleCommand = (handler: CommandHandler) => async (migration: string, opt
     const adapter = adapterForName(spec.adapter, migrationContext);
     migrationContext.adapter = adapter;
 
-    const selectedRepos = options.repos && options.repos.map(adapter.parseSelectedRepo);
+    const selectedRepos = options.repos && options.repos.map(adapter.parseRepo);
     migrationContext.migration.selectedRepos = selectedRepos;
 
     // The list of repos be null if migration hasn't started yet

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -9,6 +9,6 @@ export default async (context: IMigrationContext) => {
   } = context;
 
   for (const repo of (repos || [])) {
-    logger.info(adapter.formatRepo(repo));
+    logger.info(adapter.stringifyRepo(repo));
   }
 };

--- a/src/util/for-each-repo.ts
+++ b/src/util/for-each-repo.ts
@@ -24,7 +24,7 @@ export default async (context: IMigrationContext, handler: RepoHandler) => {
   }
 
   for (const repo of repos) {
-    logger.info(chalk.bold(`\n[${adapter.formatRepo(repo)}]`));
+    logger.info(chalk.bold(`\n[${adapter.stringifyRepo(repo)}]`));
     // Quick sanity check in case we're working from user-selected repos
     const repoDir = adapter.getRepoDir(repo);
     if (!await existsAsync(repoDir)) {


### PR DESCRIPTION
This pull request adds some docs explaining what adapters are and how repositories are handled internally.

I also refactored the `GithubAdapter` into an abstract base class `GitAdapter` and a `GithubAdapter` subclass. This will make it easier to add support for other git-based adapters for services like GitLab or Bitbucket.