### PR TITLE
Store state in JSON file; migrate from YAML

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:watch": "npm run build -- --watch --verbose",
     "lint": "tslint -p . -c tslint.json 'src/**/*.ts'",
     "fix-lint": "npm run lint -- --fix",
-    "test": "jest src/"
+    "test": "jest --coverage src/"
   },
   "repository": {
     "type": "git",

--- a/src/util/__fixtures__/repos.yml
+++ b/src/util/__fixtures__/repos.yml
@@ -1,2 +1,0 @@
-- owner: NerdWallet
-  name: test


### PR DESCRIPTION
State of checked-out repos will now be stored in a JSON file instead of YAML. This will automatically migrate from an existing YAML file to JSON the first time it's read from or written to.

Also improved our test coverage and changed Jest to print a coverage report.

Fixes #5