### PR TITLE
Replace react-dom render with react dom hydrate

### DIFF
--- a/examples/react-16/shepherd.yml
+++ b/examples/react-16/shepherd.yml
@@ -11,6 +11,7 @@ hooks:
     - npm i prop-types
     - npm uninstall react-addons-test-utils
     - git grep -l react-addons-test-utils -- ':!package.json' ':!package-lock.json' | xargs sed -i '' 's/react-addons-test-utils/react-dom\/test-utils/g'
+    - [ -f client/main.jsx ] && sed -i '' 's/ReactDOM\.render/ReactDOM\.hydrate/g' client/main.jsx
     - rm -rf node_modules
     - rm package-lock.json
     - npm i


### PR DESCRIPTION
/review @nwalters512 @parshap -- Replaces ReactDOM.render with ReactDOM.hydrate in client/main.jsx for nw-app-build@3 compatibility. Should be merged along with updating nw-react for https://github.com/NerdWallet/nw-react/pull/29