### PR TITLE
React 16: Always exit ReactDOM.render -> ReactDOM.render replacement with status 0

### DIFF
--- a/examples/react-16/shepherd.yml
+++ b/examples/react-16/shepherd.yml
@@ -16,7 +16,7 @@ hooks:
     - npm uninstall react-addons-test-utils
     - git grep -l react-addons-test-utils -- ':!package.json' ':!package-lock.json' | xargs sed -i '' 's/react-addons-test-utils/react-dom\/test-utils/g'
     # Use ReactDOM.hydrate()
-    - [ -f client/main.jsx ] && sed -i '' 's/ReactDOM\.render/ReactDOM\.hydrate/g' client/main.jsx
+    - [ -f client/main.jsx ] && sed -i '' 's/ReactDOM\.render/ReactDOM\.hydrate/g' client/main.jsx || echo 'No client/main.jsx file found, skipping ReactDOM.render -> hydrate replacement'
     # Update to @nerdwallet/react-router if on react-router@1
     - $SHEPHERD_MIGRATION_DIR/update_react_router.sh
     # Update to react-transition-group


### PR DESCRIPTION
/review @nwalters512 @parshap --

A bunch of apply steps failed because the ReactDOM.render -> ReactDOM.hydrate step exited with status 1 if `client/main.jsx` didn't exist 