### PR TITLE
Wrap PR status check in try-catch

### DIFF
--- a/src/commands/pr-status.ts
+++ b/src/commands/pr-status.ts
@@ -6,8 +6,13 @@ export default async (context: IMigrationContext) => {
 
   await forEachRepo(context, async (repo) => {
     const spinner = logger.spinner('Determining repo PR status');
-    const status = await adapter.getPullRequestStatus(repo);
-    spinner.destroy();
-    status.forEach((s) => logger.info(s));
+    try {
+      const status = await adapter.getPullRequestStatus(repo);
+      spinner.destroy();
+      status.forEach((s) => logger.info(s));
+    } catch (e) {
+      logger.error(e);
+      spinner.fail('Failed to determine PR status');
+    }
   });
 };


### PR DESCRIPTION
The adapter can sometimes throw an error for this call, so we need to catch that so we can proceed with the rest of the repos if one fails.