### PR TITLE
Save default branch at checkout

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -11,6 +11,8 @@ interface IRepoAdapter {
 
   stringifyRepo(repo: IRepo): string;
 
+  mapRepoAfterCheckout(repo: Readonly<IRepo>): Promise<IRepo>;
+
   checkoutRepo(repo: IRepo): Promise<void>;
 
   resetRepo(repo: IRepo): Promise<void>;

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -25,6 +25,8 @@ abstract class GitAdapter implements IRepoAdapter {
 
   public abstract getDataDir(repo: IRepo): string;
 
+  public abstract mapRepoAfterCheckout(repo: Readonly<IRepo>): Promise<IRepo>;
+
   public async checkoutRepo(repo: IRepo): Promise<void> {
     const repoPath = this.getRepositoryUrl(repo);
     const localPath = this.getRepoDir(repo);
@@ -33,7 +35,9 @@ abstract class GitAdapter implements IRepoAdapter {
       // Repo already exists; just fetch
       await this.git(repo).fetch('origin');
     } else {
-      await simpleGit().clone(repoPath, localPath);
+      const git = simpleGit();
+      git.silent(true);
+      await git.clone(repoPath, localPath);
     }
 
     // We'll immediately create and switch to a new branch


### PR DESCRIPTION
I couldn't do this directly in `getCandidateRepos`, as that isn't called when `--repos` are specified. I opted to add a new adapter method that can do this work for all checked-out repos after they've been checked out.

I'm beginning to think that `BaseAdapter` should actually be an abstract class instead of an interface - this new function should probably be a no-op by default.