### PR TITLE
Add automatic npm deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,27 @@
 language: node_js
 node_js:
-- 6
-- 8
-- 10
+  - 6
+  - 8
+  - 10
 cache:
   directories:
-  - node_modules
+    - node_modules
+
 script:
-- npm run lint
-- npm run build
-- npm run test
-deploy:
-  provider: npm
-  email: "npm@nerdwallet.com"
-  on:
-    tags: true
-    branch: master
-    # Only publish from the Node 10 job in the build matrix
-    node: 10
-  skip_cleanup: true
-  api_key:
-    secure: pVg+rCrDhJhU6wa9NvU1/rR+wI4vpYzqtT21tdFh+WJRbBLNz/ECfRKgIejp5zaSHcIXgsa+pZXwTHpldoYDBBnIQDb5NmEScurUBPwzmuwP0tMODxMnksv7ltTGqvwwdnfOH9gl/dKqXKZn65BL+xLmBaCXsGsQm9BlG1t4NK1kRHawLifu4jaHcuM1dJ1sLGSUqOry72Z7ZW2Io9vAHpUtxGYUN5wzUJtuOrtN2iRlW3py2A2mfzlQHNbWSH3yWywo1znOnmIvw2FeVnjmU3MPuDVi0SDtqm3JNNKX1fwTfAtSVrp8BHdcYa1oxtnBkDUJ7LdGwGCFtfEwrp0UCoJiHE8HbaJbltjoucJ9rXJ0oFzFWy8L7BJoG+4rHumqgYzCDinOfSTpj6OHydXf5Cn4hlnGP27nMH+bMMOfMUZCKDdnFjamk0Yi1XdsdwXqxWf7d+P7V3mvVh35c7PgR47sQ9HmMQQJXTPuoYxu+fRwkau7Q/eumHDCxFQBRWmLdwJf9aiNbUk19cKzO6emb1Xo3h8HOuc/Ib79p5P23LnHTLzFZnBt4xG7xBVap7FFRjfq2xgdTTYonoVZ7m306GQxydsJWXQMN09A/Qz9YhbQ+PiLMiJfjqL2dTGoVU/evhLhyCFD+snAvuJ3Ak6oW2CW+Sj9q0A3wovVE59ceWs=
+  - npm run lint
+  - npm run build
+  - npm run test
+
+jobs:
+  include:
+    - stage: npm release
+      node_js: "10"
+      script: echo "Publishing to npm..."
+      deploy:
+        provider: npm
+        on:
+          tags: true
+          branch: master
+        email: "npm@nerdwallet.com"
+        api_key:
+          secure: pVg+rCrDhJhU6wa9NvU1/rR+wI4vpYzqtT21tdFh+WJRbBLNz/ECfRKgIejp5zaSHcIXgsa+pZXwTHpldoYDBBnIQDb5NmEScurUBPwzmuwP0tMODxMnksv7ltTGqvwwdnfOH9gl/dKqXKZn65BL+xLmBaCXsGsQm9BlG1t4NK1kRHawLifu4jaHcuM1dJ1sLGSUqOry72Z7ZW2Io9vAHpUtxGYUN5wzUJtuOrtN2iRlW3py2A2mfzlQHNbWSH3yWywo1znOnmIvw2FeVnjmU3MPuDVi0SDtqm3JNNKX1fwTfAtSVrp8BHdcYa1oxtnBkDUJ7LdGwGCFtfEwrp0UCoJiHE8HbaJbltjoucJ9rXJ0oFzFWy8L7BJoG+4rHumqgYzCDinOfSTpj6OHydXf5Cn4hlnGP27nMH+bMMOfMUZCKDdnFjamk0Yi1XdsdwXqxWf7d+P7V3mvVh35c7PgR47sQ9HmMQQJXTPuoYxu+fRwkau7Q/eumHDCxFQBRWmLdwJf9aiNbUk19cKzO6emb1Xo3h8HOuc/Ib79p5P23LnHTLzFZnBt4xG7xBVap7FFRjfq2xgdTTYonoVZ7m306GQxydsJWXQMN09A/Qz9YhbQ+PiLMiJfjqL2dTGoVU/evhLhyCFD+snAvuJ3Ak6oW2CW+Sj9q0A3wovVE59ceWs=

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 - npm run test
 deploy:
   provider: npm
-  email: 
+  email: "npm@nerdwallet.com"
   on:
     tags: true
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ deploy:
   on:
     tags: true
     branch: master
+    # Only publish from the Node 10 job in the build matrix
+    node: 10
   skip_cleanup: true
   api_key:
     secure: pVg+rCrDhJhU6wa9NvU1/rR+wI4vpYzqtT21tdFh+WJRbBLNz/ECfRKgIejp5zaSHcIXgsa+pZXwTHpldoYDBBnIQDb5NmEScurUBPwzmuwP0tMODxMnksv7ltTGqvwwdnfOH9gl/dKqXKZn65BL+xLmBaCXsGsQm9BlG1t4NK1kRHawLifu4jaHcuM1dJ1sLGSUqOry72Z7ZW2Io9vAHpUtxGYUN5wzUJtuOrtN2iRlW3py2A2mfzlQHNbWSH3yWywo1znOnmIvw2FeVnjmU3MPuDVi0SDtqm3JNNKX1fwTfAtSVrp8BHdcYa1oxtnBkDUJ7LdGwGCFtfEwrp0UCoJiHE8HbaJbltjoucJ9rXJ0oFzFWy8L7BJoG+4rHumqgYzCDinOfSTpj6OHydXf5Cn4hlnGP27nMH+bMMOfMUZCKDdnFjamk0Yi1XdsdwXqxWf7d+P7V3mvVh35c7PgR47sQ9HmMQQJXTPuoYxu+fRwkau7Q/eumHDCxFQBRWmLdwJf9aiNbUk19cKzO6emb1Xo3h8HOuc/Ib79p5P23LnHTLzFZnBt4xG7xBVap7FFRjfq2xgdTTYonoVZ7m306GQxydsJWXQMN09A/Qz9YhbQ+PiLMiJfjqL2dTGoVU/evhLhyCFD+snAvuJ3Ak6oW2CW+Sj9q0A3wovVE59ceWs=

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
 jobs:
   include:
     - stage: npm release
+      # Only run this job on master
+      if: branch = master
       node_js: "10"
       script: echo "Publishing to npm..."
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: node_js
 node_js:
-  - 6
-  - 8
-  - 10
+- 6
+- 8
+- 10
 cache:
   directories:
-    - "node_modules"
+  - node_modules
 script:
-  - npm run lint
-  - npm run build
-  - npm run test
+- npm run lint
+- npm run build
+- npm run test
+deploy:
+  provider: npm
+  email: 
+  on:
+    tags: true
+    branch: master
+  skip_cleanup: true
+  api_key:
+    secure: pVg+rCrDhJhU6wa9NvU1/rR+wI4vpYzqtT21tdFh+WJRbBLNz/ECfRKgIejp5zaSHcIXgsa+pZXwTHpldoYDBBnIQDb5NmEScurUBPwzmuwP0tMODxMnksv7ltTGqvwwdnfOH9gl/dKqXKZn65BL+xLmBaCXsGsQm9BlG1t4NK1kRHawLifu4jaHcuM1dJ1sLGSUqOry72Z7ZW2Io9vAHpUtxGYUN5wzUJtuOrtN2iRlW3py2A2mfzlQHNbWSH3yWywo1znOnmIvw2FeVnjmU3MPuDVi0SDtqm3JNNKX1fwTfAtSVrp8BHdcYa1oxtnBkDUJ7LdGwGCFtfEwrp0UCoJiHE8HbaJbltjoucJ9rXJ0oFzFWy8L7BJoG+4rHumqgYzCDinOfSTpj6OHydXf5Cn4hlnGP27nMH+bMMOfMUZCKDdnFjamk0Yi1XdsdwXqxWf7d+P7V3mvVh35c7PgR47sQ9HmMQQJXTPuoYxu+fRwkau7Q/eumHDCxFQBRWmLdwJf9aiNbUk19cKzO6emb1Xo3h8HOuc/Ib79p5P23LnHTLzFZnBt4xG7xBVap7FFRjfq2xgdTTYonoVZ7m306GQxydsJWXQMN09A/Qz9YhbQ+PiLMiJfjqL2dTGoVU/evhLhyCFD+snAvuJ3Ak6oW2CW+Sj9q0A3wovVE59ceWs=

--- a/package.json
+++ b/package.json
@@ -2,31 +2,49 @@
   "name": "@nerdwallet/shepherd",
   "version": "1.0.0",
   "description": "A utility for applying code changes across many repositories",
-  "scripts": {
-    "build": "tsc",
-    "build:watch": "npm run build -- --watch",
-    "lint": "tslint -p . -c tslint.json 'src/**/*.ts'",
-    "fix-lint": "npm run lint -- --fix",
-    "test": "jest --coverage src/"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/NerdWalletOSS/shepherd.git"
-  },
   "keywords": [
     "codemod",
     "codemods",
     "migration"
   ],
-  "author": "Nathan Walters",
-  "license": "Apache-2.0",
+  "homepage": "https://github.com/NerdWalletOSS/shepherd#readme",
   "bugs": {
     "url": "https://github.com/NerdWalletOSS/shepherd/issues"
   },
-  "homepage": "https://github.com/NerdWalletOSS/shepherd#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NerdWalletOSS/shepherd.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Nathan Walters",
   "bin": {
     "shepherd": "./lib/cli.js"
   },
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "npm run build -- --watch",
+    "fix-lint": "npm run lint -- --fix",
+    "lint": "tslint -p . -c tslint.json 'src/**/*.ts'",
+    "prepublishOnly": "npm run test && npm run build",
+    "test": "jest --coverage src/"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    }
+  },
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@octokit/rest": "^15.9.4",
     "@types/js-yaml": "^3.11.2",
@@ -58,19 +76,5 @@
     "ts-jest": "^23.0.1",
     "tslint": "^5.11.0",
     "typescript": "^3.0.1"
-  },
-  "jest": {
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ]
   }
 }


### PR DESCRIPTION
This will automatically release Shepherd on npm when a new tag is pushed to the repo. This is untested but will only run on master, so it might take a bit of trial and error to get things working correctly.