### PR TITLE
Fix bug in travis deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,13 @@ jobs:
   include:
     - stage: npm release
       # Only run this job on master
-      if: branch = master
+      if: tag IS present
       node_js: "10"
       script: echo "Publishing to npm..."
       deploy:
         provider: npm
         on:
           tags: true
-          branch: master
         email: "npm@nerdwallet.com"
         api_key:
           secure: pVg+rCrDhJhU6wa9NvU1/rR+wI4vpYzqtT21tdFh+WJRbBLNz/ECfRKgIejp5zaSHcIXgsa+pZXwTHpldoYDBBnIQDb5NmEScurUBPwzmuwP0tMODxMnksv7ltTGqvwwdnfOH9gl/dKqXKZn65BL+xLmBaCXsGsQm9BlG1t4NK1kRHawLifu4jaHcuM1dJ1sLGSUqOry72Z7ZW2Io9vAHpUtxGYUN5wzUJtuOrtN2iRlW3py2A2mfzlQHNbWSH3yWywo1znOnmIvw2FeVnjmU3MPuDVi0SDtqm3JNNKX1fwTfAtSVrp8BHdcYa1oxtnBkDUJ7LdGwGCFtfEwrp0UCoJiHE8HbaJbltjoucJ9rXJ0oFzFWy8L7BJoG+4rHumqgYzCDinOfSTpj6OHydXf5Cn4hlnGP27nMH+bMMOfMUZCKDdnFjamk0Yi1XdsdwXqxWf7d+P7V3mvVh35c7PgR47sQ9HmMQQJXTPuoYxu+fRwkau7Q/eumHDCxFQBRWmLdwJf9aiNbUk19cKzO6emb1Xo3h8HOuc/Ib79p5P23LnHTLzFZnBt4xG7xBVap7FFRjfq2xgdTTYonoVZ7m306GQxydsJWXQMN09A/Qz9YhbQ+PiLMiJfjqL2dTGoVU/evhLhyCFD+snAvuJ3Ak6oW2CW+Sj9q0A3wovVE59ceWs=


### PR DESCRIPTION
Running a deploy from a tag was broken because tags aren't considered on `master`. This removes branch checking so that we'll deploy for any tag.