### PR TITLE
Skip cleanup during travis npm publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
       script: echo "Publishing to npm..."
       deploy:
         provider: npm
+        skip_cleanup: true
         on:
           tags: true
         email: "npm@nerdwallet.com"


### PR DESCRIPTION
This prevents `node_modules` from being deleted before we try to run tests and publish.