### PR TITLE
Update publish config to make the package public

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "ts-jest": "^23.0.1",
     "tslint": "^5.11.0",
     "typescript": "^3.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
By default, scoped packages are published as private. This makes our package public.