### PR TITLE
Fix commit check logic to compare HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ When new features, bug fixes, and so on are added to Shepherd, there should be a
 
 ## [Upcoming]
 
+* Fix commit check logic when checking for non-Shepherd commits
+
 ## v1.0.0
 
 * Initial public releast to npm :tada:

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -263,7 +263,7 @@ class GithubAdapter extends GitAdapter {
   }
 
   private async checkActionSafety(repo: IRepo): Promise<SafetyStatus> {
-    const { owner, name, defaultBranch } = repo;
+    const { owner, name } = repo;
 
     // Get all branches and look for the remote branch
     // @ts-ignore (typings are broken)
@@ -291,7 +291,7 @@ class GithubAdapter extends GitAdapter {
       // all from Shepherd. If they are, it's safe to reset the branch to
       // master.
       const commits = await this.git(repo).log({
-        from: defaultBranch,
+        from: 'HEAD',
         to: `remotes/origin/${this.branchName}`,
       });
       const allShepherd = commits.all.every(({ message }) => this.isShepherdCommitMessage(message));


### PR DESCRIPTION
When looking for non-Shepherd commits that may have been added to the PR branch, we should compare the current repo HEAD to the upstream branch, not `master` to the upstream branch.

@NerdWalletOSS/shepherd 