### PR TITLE
Use shallow git clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ When new features, bug fixes, and so on are added to Shepherd, there should be a
 
 ## [Upcoming]
 
+* Use shallow git clones
+
 ## v1.0.2
+
 * Fix for issue hitting GitHub rate limiting when operating on very large result sets by abiding by
 the retry-after response header on failure
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ shepherd <command> <migration> [options]
 
 There are a number of commands that must be run to execute a migration:
 
-* `checkout`: Determines which repositories are candidates for migration and clones or updates the repositories on your machine. Uses `should_migrate` to decide if a repository should be kept after it's checked out.
+* `checkout`: Determines which repositories are candidates for migration and clones or updates the repositories on your machine. Clones are "shallow", containing no git history. Uses `should_migrate` to decide if a repository should be kept after it's checked out.
 * `apply`: Performs the migration using the `apply` hook discussed above.
 * `commit`: Makes a commit with any changes that were made during the `apply` step, including adding newly-created files. The migration's `title` will be prepended with `[shepherd]` and used as the commit message.
 * `push`: Pushes all commits to their respective repositories.

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -39,7 +39,7 @@ abstract class GitAdapter implements IRepoAdapter {
     } else {
       const git = simpleGit();
       git.silent(true);
-      await git.clone(repoPath, localPath);
+      await git.clone(repoPath, localPath, ['--depth', '1']);
     }
 
     // We'll immediately create and switch to a new branch


### PR DESCRIPTION
Git repo history is not needed, this should make cloning faster.