### PR TITLE
Always log stderr of hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ When new features, bug fixes, and so on are added to Shepherd, there should be a
 ## [Upcoming]
 
 * Use shallow git clones
+* Always log stderr of hooks
 
 ## v1.0.2
 

--- a/src/util/execute-steps.ts
+++ b/src/util/execute-steps.ts
@@ -42,8 +42,8 @@ export default async (
       const { promise, childProcess } = execInRepo(context, repo, step);
       if (showOutput) {
         childProcess.stdout.on('data', (out) => logger.info(out.toString().trim()));
-        childProcess.stderr.on('data', (out) => logger.info(out.toString().trim()));
       }
+      childProcess.stderr.on('data', (out) => logger.info(out.toString().trim()));
       const childProcessResult = await promise;
       logger.info(chalk.green(`Step "${step}" exited with 0`));
       results.stepResults.push({


### PR DESCRIPTION
This makes sure errors are printed when a pr hook fails.