### PR TITLE
Set branch origin/target spec in migration

### DIFF
--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra-promise';
 import simpleGit, { SimpleGit } from 'simple-git/promise';
 
 import { IMigrationContext } from '../migration-context';
-import IRepoAdapter, {IRepo, RetryMethod} from './base';
+import IRepoAdapter, { IRepo, RetryMethod } from './base';
 
 abstract class GitAdapter implements IRepoAdapter {
   protected migrationContext: IMigrationContext;
@@ -39,7 +39,13 @@ abstract class GitAdapter implements IRepoAdapter {
     } else {
       const git = simpleGit();
       git.silent(true);
-      await git.clone(repoPath, localPath, ['--depth', '1']);
+
+      const gitArgs = ['--depth', '1'];
+      if (this.migrationContext.migration.origin) {
+        gitArgs.push('-b', this.migrationContext.migration.origin, '--single-branch');
+      }
+
+      await git.clone(repoPath, localPath, gitArgs);
     }
 
     // We'll immediately create and switch to a new branch

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -42,7 +42,7 @@ abstract class GitAdapter implements IRepoAdapter {
 
       const gitArgs = ['--depth', '1'];
       if (this.migrationContext.migration.origin) {
-        gitArgs.push('-b', this.migrationContext.migration.origin, '--single-branch');
+        gitArgs.push('-b', this.migrationContext.migration.origin);
       }
 
       await git.clone(repoPath, localPath, gitArgs);

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -131,6 +131,7 @@ class GithubAdapter extends GitAdapter {
   public async createPullRequest(repo: IRepo, message: string): Promise<void> {
     const { migration: { spec } } = this.migrationContext;
     const { owner, name, defaultBranch } = repo;
+    const baseBranch = spec.target || defaultBranch;
 
     // Let's check if a PR already exists
     const { data: pullRequests } = await this.octokit.pullRequests.list({
@@ -161,7 +162,7 @@ class GithubAdapter extends GitAdapter {
         owner,
         repo: name,
         head: this.branchName,
-        base: defaultBranch,
+        base: baseBranch,
         title: spec.title,
         body: message,
       });

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -88,7 +88,7 @@ class GithubAdapter extends GitAdapter {
   }
 
   public async resetRepoBeforeApply(repo: IRepo, force: boolean) {
-    const { defaultBranch } = repo;
+    const branch = this.migrationContext.migration.origin || repo.defaultBranch;
     // First, get any changes from the remote
     // --prune will ensure that any remote branch deletes are reflected here
     await this.git(repo).fetch(['origin', '--prune']);
@@ -103,7 +103,7 @@ class GithubAdapter extends GitAdapter {
     }
 
     // If we got this far, we can go ahead and reset to the default branch
-    await this.git(repo).reset(['--hard', `origin/${defaultBranch}`]);
+    await this.git(repo).reset(['--hard', `origin/${branch}`]);
   }
 
   public async pushRepo(repo: IRepo, force: boolean): Promise<void> {
@@ -192,7 +192,7 @@ class GithubAdapter extends GitAdapter {
       status.push(`PR #${pullRequest.number} [${pullRequest.html_url}]`);
       if (pullRequest.merged_at) {
         status.push(`PR was merged at ${pullRequest.merged_at}`);
-      // @ts-ignore: mergeable_state is not included in @octokit/rest type definition
+        // @ts-ignore: mergeable_state is not included in @octokit/rest type definition
       } else if (pullRequest.mergeable && pullRequest.mergeable_state === 'clean') {
         status.push(chalk.green('PR is mergeable!'));
       } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,8 @@ const handleCommand = (handler: CommandHandler) => async (migration: string, opt
     const migrationContext = {
       migration: {
         migrationDirectory: path.resolve(migration),
+        origin: spec.origin,
+        target: spec.target,
         spec,
         workingDirectory: migrationWorkingDirectory,
       },

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -29,7 +29,8 @@ export default async (context: IMigrationContext) => {
     }
     spinner.succeed('Generated PR message');
 
-    const prSpinner = logger.spinner('Creating pull request');
+    const branchDisplay = context.migration.target || 'default branch';
+    const prSpinner = logger.spinner(`Creating pull request to ${branchDisplay}`);
     try {
       await context.adapter.createPullRequest(repo, message);
       prSpinner.succeed('Pull request created');

--- a/src/migration-context.ts
+++ b/src/migration-context.ts
@@ -11,6 +11,8 @@ export interface IMigrationInfo {
   migrationDirectory: string;
   workingDirectory: string;
   repos: IRepo[] | null;
+  origin: string;
+  target: string;
   selectedRepos?: IRepo[];
 }
 

--- a/src/util/migration-spec.ts
+++ b/src/util/migration-spec.ts
@@ -17,6 +17,8 @@ export type MigrationPhase = [keyof IMigrationHooks];
 export interface IMigrationSpec {
   id: string;
   title: string;
+  origin: string;
+  target: string;
   adapter: {
     type: string;
     [key: string]: any;
@@ -58,6 +60,8 @@ export function validateSpec(spec: any) {
   const schema = Joi.object().keys({
     id: Joi.string().required(),
     title: Joi.string().required(),
+    origin: Joi.string(),
+    target: Joi.string(),
     adapter: Joi.object().keys({
       type: Joi.string().allow(['github']).required(),
     }).unknown(true).required(),


### PR DESCRIPTION
An opposite idea to specifying target/origin branch through flags: https://github.com/NerdWalletOSS/shepherd/pull/71

Now we can specify in `shepherd.yml` the fields `origin` and `target` like:

```yml
id: weekly-merge
title: Weekly merge
origin: master
target: release
```

Without changing any commands :)
Feel free to criticize any of suggestions.