### PR TITLE
Remove ../ from a node_modules import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ When new features, bug fixes, and so on are added to Shepherd, there should be a
 
 ## [Upcoming]
 
+* Fix an import of a dependency that uses `../../node_modules`
+
 ## v1.1.0
 
 * Use shallow git clones

--- a/src/util/execute-steps.ts
+++ b/src/util/execute-steps.ts
@@ -1,4 +1,4 @@
-import chalk from '../../node_modules/chalk';
+import chalk from 'chalk';
 import { IRepo } from '../adapters/base';
 import { IMigrationContext } from '../migration-context';
 import execInRepo from '../util/exec-in-repo';


### PR DESCRIPTION
I'm not sure why this file imports from `../../node_modules/<dependency>` but it's currently breaking my CLI usage when installing with yarn

**EDIT**: I assumed this was `yarn` but it also happens with `npm`