### PR TITLE
Throw a more useful error if no github credentials are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ When new features, bug fixes, and so on are added to Shepherd, there should be a
 
 ## [Upcoming]
 
+* Throw a clearer error when there are no Github credentials found
 * Fix an import of a dependency that uses `../../node_modules`
 
 ## v1.1.0

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -40,6 +40,9 @@ class GithubAdapter extends GitAdapter {
         });
       } else {
         const netrcAuth = netrc();
+        if (!netrcAuth['api.github.com']) {
+          throw new Error('No Github credentials found; set either GITHUB_TOKEN or set user/password for api.github.com in ~/.netrc');
+        }
         // TODO: we could probably fail gracefully if there's no GITHUB_TOKEN
         // and also no .netrc credentials
         this.octokit.authenticate({

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -41,7 +41,8 @@ class GithubAdapter extends GitAdapter {
       } else {
         const netrcAuth = netrc();
         if (!netrcAuth['api.github.com']) {
-          throw new Error('No Github credentials found; set either GITHUB_TOKEN or set user/password for api.github.com in ~/.netrc');
+          throw new Error('No Github credentials found; set either GITHUB_TOKEN or' +
+            ' set user/password for api.github.com in ~/.netrc');
         }
         // TODO: we could probably fail gracefully if there's no GITHUB_TOKEN
         // and also no .netrc credentials


### PR DESCRIPTION
Fixes #77

It's also a partial fix for #61 I think

I'm like 90% sure this is a good change because you'd need Github creds to be able to push a branch for a PR, but I don't know all the use-cases for this tool yet so 🤷‍♂I could be wrong!