### PR TITLE
Add SHEPHERD_BASE_BRANCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 When new features, bug fixes, and so on are added to Shepherd, there should be a corresponding entry made in the changelog under the *[Upcoming]* header.
 
+## [Upcoming]
+* Add `SHEPHERD_MERGE_BRANCH` environment variable for all steps run after `checkout`.
+
 ## v1.3.0
 
 * Throw a clearer error when there are no Github credentials found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 When new features, bug fixes, and so on are added to Shepherd, there should be a corresponding entry made in the changelog under the *[Upcoming]* header.
 
 ## [Upcoming]
-* Add `SHEPHERD_MERGE_BRANCH` environment variable for all steps run after `checkout`.
+* Add `SHEPHERD_BASE_BRANCH` environment variable for all steps run after `checkout`.
 * Add magenta highlighting to merged PRs
 
 ## v1.3.0

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Each of these commands will be executed with the working directory set to the ta
 
 * `SHEPHERD_REPO_DIR` is the absolute path to the repository being operated on. This will be the working directory when commands are executed.
 * `SHEPHERD_DATA_DIR` is the absolute path to a special directory that can be used to persist state between steps. This would be useful if, for instance, a `jscodeshift` codemod in your `apply` hook generates a list of files that need human attention and you want to use that list in your `pr_message` hook.
-* `SHEPHERD_MERGE_BRANCH` is the name of the branch Shepherd will set up a pull-request against. This will often, _but not always_, be master. Only available for `apply` and later steps.
+* `SHEPHERD_BASE_BRANCH` is the name of the branch Shepherd will set up a pull-request against. This will often, _but not always_, be master. Only available for `apply` and later steps.
 * `SHEPHERD_MIGRATION_DIR` is the absolute path to the directory containing your migration's `shepherd.yml` file. This is useful if you want to include a script with your migration spec and need to reference that command in a hook. For instance, if I have a script `pr.sh` that will generate a PR message: my `pr_message` hook might look something like this:
 
   ```yml

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Each of these commands will be executed with the working directory set to the ta
 
 * `SHEPHERD_REPO_DIR` is the absolute path to the repository being operated on. This will be the working directory when commands are executed.
 * `SHEPHERD_DATA_DIR` is the absolute path to a special directory that can be used to persist state between steps. This would be useful if, for instance, a `jscodeshift` codemod in your `apply` hook generates a list of files that need human attention and you want to use that list in your `pr_message` hook.
+* `SHEPHERD_MERGE_BRANCH` is the name of the branch Shepherd will set up a pull-request against. This will often, _but not always_, be master. Only available for `apply` and later steps.
 * `SHEPHERD_MIGRATION_DIR` is the absolute path to the directory containing your migration's `shepherd.yml` file. This is useful if you want to include a script with your migration spec and need to reference that command in a hook. For instance, if I have a script `pr.sh` that will generate a PR message: my `pr_message` hook might look something like this:
 
   ```yml

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -32,6 +32,8 @@ interface IRepoAdapter {
   getRepoDir(repo: IRepo): string;
 
   getDataDir(repo: IRepo): string;
+
+  getBaseBranch(repo: IRepo): string;
 }
 
 export default IRepoAdapter;

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -81,6 +81,8 @@ abstract class GitAdapter implements IRepoAdapter {
 
   public abstract getPullRequestStatus(repo: IRepo): Promise<string[]>;
 
+  public abstract getBaseBranch(repo: IRepo): string;
+
   protected abstract getRepositoryUrl(repo: IRepo): string;
 
   protected git(repo: IRepo): SimpleGit {

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -280,6 +280,10 @@ class GithubAdapter extends GitAdapter {
     return path.join(this.migrationContext.migration.workingDirectory, 'data', repo.owner, repo.name);
   }
 
+  public getBaseBranch(repo: IRepo): string {
+    return repo.defaultBranch;
+  }
+
   protected getRepositoryUrl(repo: IRepo): string {
     return `git@github.com:${repo.owner}/${repo.name}.git`;
   }

--- a/src/util/exec-in-repo.ts
+++ b/src/util/exec-in-repo.ts
@@ -20,7 +20,7 @@ export default (context: IMigrationContext, repo: IRepo, command: string): IExec
       SHEPHERD_REPO_DIR: repoDir,
       SHEPHERD_DATA_DIR: dataDir,
       SHEPHERD_MIGRATION_DIR: migrationDir,
-      SHEPHERD_MERGE_BRANCH: baseBranch,
+      SHEPHERD_BASE_BRANCH: baseBranch,
     },
     shell: true,
     capture: [ 'stdout', 'stderr' ],

--- a/src/util/exec-in-repo.ts
+++ b/src/util/exec-in-repo.ts
@@ -11,6 +11,7 @@ interface IExecRepoResult {
 export default (context: IMigrationContext, repo: IRepo, command: string): IExecRepoResult => {
   const repoDir = context.adapter.getRepoDir(repo);
   const dataDir = context.adapter.getDataDir(repo);
+  const baseBranch = context.adapter.getBaseBranch(repo);
   const migrationDir = context.migration.migrationDirectory;
   const execOptions = {
     cwd: repoDir,
@@ -19,6 +20,7 @@ export default (context: IMigrationContext, repo: IRepo, command: string): IExec
       SHEPHERD_REPO_DIR: repoDir,
       SHEPHERD_DATA_DIR: dataDir,
       SHEPHERD_MIGRATION_DIR: migrationDir,
+      SHEPHERD_MERGE_BRANCH: baseBranch,
     },
     shell: true,
     capture: [ 'stdout', 'stderr' ],


### PR DESCRIPTION
Occasionally repositories are set up with their default branch as not master, and some migrations may need that information. E.g. I was working on a migration to add main-branch-only build notifications, and had no way to figure out what that branch was.