### PR TITLE
Enable adapters to add environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 When new features, bug fixes, and so on are added to Shepherd, there should be a corresponding entry made in the changelog under the *[Upcoming]* header.
 
 ## [Upcoming]
+* Add adapter specific environment variables for all steps run after `checkout`.
 * Add `SHEPHERD_BASE_BRANCH` environment variable for all steps run after `checkout`.
 * Add magenta highlighting to merged PRs
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The options under `hooks` specify the meat of a migration. They tell Shepherd ho
 
 `should_migrate` and `post_checkout` are optional; `apply` and `pr_message` are required.
 
-Each of these commands will be executed with the working directory set to the target repository. Shepherd exposes some context to each command via specific environment variables:
+Each of these commands will be executed with the working directory set to the target repository. Shepherd exposes some context to each command via specific environment variables. Some additional enviornment variables are exposed when using the `git` or `github` adapters.
 
 * `SHEPHERD_REPO_DIR` is the absolute path to the repository being operated on. This will be the working directory when commands are executed.
 * `SHEPHERD_DATA_DIR` is the absolute path to a special directory that can be used to persist state between steps. This would be useful if, for instance, a `jscodeshift` codemod in your `apply` hook generates a list of files that need human attention and you want to use that list in your `pr_message` hook.
@@ -92,6 +92,9 @@ Each of these commands will be executed with the working directory set to the ta
   ```yml
   pr_message: $SHEPHERD_MIGRATION_DIR/pr.sh
   ```
+* `SHEPHERD_GIT_REVISION` (`git` and `github` adapters) is the current revision of the repository being operated on.
+* `SHEPHERD_GITHUB_REPO_OWNER` (`github` adapter) is the owner of the repository being operated on. For example, if operating on the repository `https://github.com/NerdWalletOSS/shepherd`, this would be `NerdWalletOSS`.
+* `SHEPHERD_GITHUB_REPO_NAME` (`github` adapter) is the name of the repository being operated on. For example, if operating on the repository `https://github.com/NerdWalletOSS/shepherd`, this would be `shepherd`.
 
 Commands follow standard Unix conventions: an exit code of 0 indicates a command succeeded, a non-zero exit code indicates failure.
 

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -2,6 +2,10 @@ export interface IRepo {
   [key: string]: any;
 }
 
+export interface IEnvironmentVariables {
+  [key: string]: string;
+}
+
 export type RetryMethod = (opts: number) => any;
 
 interface IRepoAdapter {
@@ -34,6 +38,8 @@ interface IRepoAdapter {
   getDataDir(repo: IRepo): string;
 
   getBaseBranch(repo: IRepo): string;
+
+  getEnvironmentVariables(repo: IRepo): Promise<IEnvironmentVariables>;
 }
 
 export default IRepoAdapter;

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra-promise';
 import simpleGit, { SimpleGit } from 'simple-git/promise';
 
 import { IMigrationContext } from '../migration-context';
-import IRepoAdapter, {IRepo, RetryMethod} from './base';
+import IRepoAdapter, {IEnvironmentVariables, IRepo, RetryMethod} from './base';
 
 abstract class GitAdapter implements IRepoAdapter {
   protected migrationContext: IMigrationContext;
@@ -82,6 +82,14 @@ abstract class GitAdapter implements IRepoAdapter {
   public abstract getPullRequestStatus(repo: IRepo): Promise<string[]>;
 
   public abstract getBaseBranch(repo: IRepo): string;
+
+  public async getEnvironmentVariables(repo: IRepo): Promise<IEnvironmentVariables> {
+    const revision = await this.git(repo).revparse(['HEAD']);
+
+    return {
+      SHEPHERD_GIT_REVISION: revision,
+    };
+  }
 
   protected abstract getRepositoryUrl(repo: IRepo): string;
 

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { IMigrationContext } from '../migration-context';
 import { paginate, paginateSearch } from '../util/octokit';
-import { IRepo, RetryMethod } from './base';
+import { IEnvironmentVariables, IRepo, RetryMethod } from './base';
 import GitAdapter from './git';
 
 enum SafetyStatus {
@@ -282,6 +282,16 @@ class GithubAdapter extends GitAdapter {
 
   public getBaseBranch(repo: IRepo): string {
     return repo.defaultBranch;
+  }
+
+  public async getEnvironmentVariables(repo: IRepo): Promise<IEnvironmentVariables> {
+    const superEnvVars = await super.getEnvironmentVariables(repo);
+
+    return {
+      ...superEnvVars,
+      SHEPHERD_GITHUB_REPO_OWNER: repo.owner,
+      SHEPHERD_GITHUB_REPO_NAME: repo.name,
+    };
   }
 
   protected getRepositoryUrl(repo: IRepo): string {

--- a/src/util/exec-in-repo.ts
+++ b/src/util/exec-in-repo.ts
@@ -8,11 +8,18 @@ interface IExecRepoResult {
   childProcess: ChildProcess;
 }
 
-export default (context: IMigrationContext, repo: IRepo, command: string): IExecRepoResult => {
+export default async (
+  context: IMigrationContext,
+  repo: IRepo,
+  command: string,
+): Promise<IExecRepoResult> => {
   const repoDir = context.adapter.getRepoDir(repo);
   const dataDir = context.adapter.getDataDir(repo);
   const baseBranch = context.adapter.getBaseBranch(repo);
   const migrationDir = context.migration.migrationDirectory;
+
+  const adapterEnvironmentVars = await context.adapter.getEnvironmentVariables(repo);
+
   const execOptions = {
     cwd: repoDir,
     env: {
@@ -21,6 +28,7 @@ export default (context: IMigrationContext, repo: IRepo, command: string): IExec
       SHEPHERD_DATA_DIR: dataDir,
       SHEPHERD_MIGRATION_DIR: migrationDir,
       SHEPHERD_BASE_BRANCH: baseBranch,
+      ...adapterEnvironmentVars,
     },
     shell: true,
     capture: [ 'stdout', 'stderr' ],

--- a/src/util/exec-in-repo.ts
+++ b/src/util/exec-in-repo.ts
@@ -17,7 +17,6 @@ export default async (
   const dataDir = context.adapter.getDataDir(repo);
   const baseBranch = context.adapter.getBaseBranch(repo);
   const migrationDir = context.migration.migrationDirectory;
-
   const adapterEnvironmentVars = await context.adapter.getEnvironmentVariables(repo);
 
   const execOptions = {

--- a/src/util/execute-steps.ts
+++ b/src/util/execute-steps.ts
@@ -39,7 +39,7 @@ export default async (
   for (const step of steps) {
     logger.info(`\$ ${step}`);
     try {
-      const { promise, childProcess } = execInRepo(context, repo, step);
+      const { promise, childProcess } = await execInRepo(context, repo, step);
       if (showOutput) {
         childProcess.stdout.on('data', (out) => logger.info(out.toString().trim()));
       }


### PR DESCRIPTION
I'd like my GitHub PR messages to include permalinks, so they are rendered like this:

https://github.com/NerdWalletOSS/shepherd/blob/8048f846335ab5b16c6931b01c8974d2a8914406/package.json#L2-L8

In order to do this my PR script needs to be able to generate URLs that look like:
```
https://github.com/NerdWalletOSS/shepherd/blob/8048f846335ab5b16c6931b01c8974d2a8914406/package.json#L2-L8
```

This requires the message generator to have access to the owner, repo, and revision being operated on. As far as I can tell that isn't currently possible. 

It looks like there is a precedent for some of this information as environment variables at script time, including the `branch` of the current repo:
https://github.com/NerdWalletOSS/shepherd/blob/8048f846335ab5b16c6931b01c8974d2a8914406/src/util/exec-in-repo.ts#L18-L24

Instead of hard coding more things in here that are specific to GitHub or Git, I modified the adapters to be able to specify additional environment variables. Perhaps the base branch environment variable should get moved into the `git` adapter with the `revision` env var added in this PR.