### PR TITLE
feat: add dependabot config file.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    commit_message:
+    prefix: "chore"


### PR DESCRIPTION
## Changes
- add dependabot config file.
- adds 'chore' prefix to dependabot's commit messages so that corresponding semantic-release is triggered.