### PR TITLE
chore: update dependabot config.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,14 @@
 version: 1
 update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"
-    commit_message:
-      prefix: "chore"
+    - package_manager: "javascript"
+      directory: "/"
+      update_schedule: "live"
+      commit_message:
+        prefix: "chore"
+      automerged_updates:
+        - match:
+            dependency_type: "all"
+            update_type: "semver:patch"
+        - match:
+            dependency_type: "all"
+            update_type: "security:patch"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,7 @@ update_configs:
     - package_manager: "javascript"
       directory: "/"
       update_schedule: "live"
+      version_requirement_updates: "increase_versions"
       commit_message:
         prefix: "chore"
       automerged_updates:


### PR DESCRIPTION
## Changes

This PR adds auto-merge for all production and development security and semver **patch** updates.

For production dependencies, commits messages will be prefixed with`fix` resulting in CI/CD tagging and publishing a new patch version to npm.

For development dependencies, commit messages will be prefixed with `chore` and will not result a new tag or a new patch version being published to npm.