### PR TITLE
fix: use case-insensitive compare for repo names

### DIFF
--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -100,7 +100,13 @@ class GithubAdapter extends GitAdapter {
   }
 
   public reposEqual(repo1: IRepo, repo2: IRepo): boolean {
-    return repo1.owner === repo2.owner && repo1.name === repo2.name;
+    // GitHub ignores case when differentiating organizations and repos, so we
+    // can safely use a case-insensitive compare to make things slightly easier
+    // for users who might be using a case-insensitive name on the command line.
+    return (
+      repo1.owner.toLowerCase() === repo2.owner.toLowerCase() &&
+      repo1.name.toLowerCase() === repo2.name.toLowerCase()
+    );
   }
 
   public stringifyRepo({ owner, name }: IRepo): string {


### PR DESCRIPTION
This change improves the experience of using the CLI by making repo names case insensitive. That is, the following two commands will work exactly the same:

```
shepherd pr --repos nerdwallet/foobar
shepherd pr --repos NerdWallet/FooBar
```

cc @taylor-chen