### PR TITLE
chore: auto update dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,5 +39,16 @@
     "automerge": true
   },
   "packageRules": [
+    {
+      "description": "Auto update dev dependencies",
+      "depTypeList": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "description": "Auto update non-major types dev dependencies",
+      "packagePatterns": ["^@types/"],
+      "updateTypes": ["minor", "patch"],
+      "stabilityDays": 0
+    }
   ]
 }


### PR DESCRIPTION
Also, don't auto update major types (to match installed package version)