### PR TITLE
add incomplete github api search detection

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -9,7 +9,7 @@ export interface IEnvironmentVariables {
 export type RetryMethod = (opts: number) => any;
 
 interface IRepoAdapter {
-  getCandidateRepos(onRetry: RetryMethod): Promise<IRepo[]>;
+  getCandidateRepos(onRetry: RetryMethod, failOnIncompleteSearch: boolean): Promise<IRepo[]>;
 
   parseRepo(repo: string): IRepo;
 

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -13,7 +13,7 @@ abstract class GitAdapter implements IRepoAdapter {
     this.branchName = migrationContext.migration.spec.id;
   }
 
-  public abstract getCandidateRepos(onRetry: RetryMethod): Promise<IRepo[]>;
+  public abstract getCandidateRepos(onRetry: RetryMethod, failOnIncompleteSearch: boolean): Promise<IRepo[]>;
 
   public abstract parseRepo(repo: string): IRepo;
 

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -55,7 +55,7 @@ class GithubAdapter extends GitAdapter {
     }
   }
 
-  public async getCandidateRepos(onRetry: RetryMethod): Promise<IRepo[]> {
+  public async getCandidateRepos(onRetry: RetryMethod, failOnIncompleteSearch: boolean): Promise<IRepo[]> {
     const { org, search_query } = this.migrationContext.migration.spec.adapter;
     let repoNames = [];
 
@@ -64,14 +64,14 @@ class GithubAdapter extends GitAdapter {
       if (search_query) {
         throw new Error('Cannot use both "org" and "search_query" in GitHub adapter. Pick one.');
       }
-      const repos = await paginate(this.octokit, this.octokit.repos.listForOrg, undefined, onRetry)({
+      const repos = await paginate(this.octokit, this.octokit.repos.listForOrg, undefined, onRetry, false)({
         org,
       });
       const unarchivedRepos = repos.filter((r: any) => !r.archived);
       repoNames = unarchivedRepos.map((r: any) => r.full_name).sort();
     } else {
       // github code search query.  results are less reliable
-      const searchResults = await paginateSearch(this.octokit, this.octokit.search.code, onRetry)({
+      const searchResults = await paginateSearch(this.octokit, this.octokit.search.code, onRetry, failOnIncompleteSearch)({
         q: search_query,
       });
       repoNames = searchResults.map((r: any) => r.repository.full_name).sort();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,10 @@ const addCommand = (name: string, description: string, repos: boolean, handler: 
   subprogram.action(handleCommand(handler));
 };
 
-addCommand('checkout', 'Check out any repositories that are candidates for a given migration', true, checkout);
+const checkoutCommand = buildCommand('checkout', 'Check out any repositories that are candidates for a given migration');
+addReposOption(checkoutCommand);
+checkoutCommand.option('--fail-on-incomplete-search', 'Fail if incomplete search results returned from GitHub api', false);
+checkoutCommand.action(handleCommand(checkout));
 
 const applyCommand = buildCommand('apply', 'Apply a migration to all checked out repositories');
 addReposOption(applyCommand);

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -11,7 +11,7 @@ const removeRepoDirectories = async (adapter: IRepoAdapter, repo: IRepo) => {
   await fs.remove(adapter.getDataDir(repo));
 };
 
-export default async (context: IMigrationContext) => {
+export default async (context: IMigrationContext, options: any) => {
   const {
     migration: { selectedRepos },
     adapter,
@@ -28,7 +28,7 @@ export default async (context: IMigrationContext) => {
     repos = selectedRepos;
   } else {
     const spinner = logger.spinner('Loading candidate repos');
-    repos = await adapter.getCandidateRepos(onRetry);
+    repos = await adapter.getCandidateRepos(onRetry, options.failOnIncompleteSearch);
     spinner.succeed(`Loaded ${repos.length} repos`);
   }
 
@@ -37,9 +37,9 @@ export default async (context: IMigrationContext) => {
   const checkedOutRepos: IRepo[] = [];
   const discardedRepos: IRepo[] = [];
 
-  const options = { warnMissingDirectory: false };
+  const opts = { warnMissingDirectory: false };
 
-  await forEachRepo(context, options, async (repo) => {
+  await forEachRepo(context, opts, async (repo) => {
     const spinner = logger.spinner('Checking out repo');
     try {
       await adapter.checkoutRepo(repo);


### PR DESCRIPTION
Shepherd currently does not provide a way to fail or warn that a github api search is incomplete. This PR provides a `warning` to the user if the search is incomplete and a flag `shepherd checkout --fail-on-incomplete-search migration` to fail the migration. 

This is the first time I have ventured into Typescript so please do let me know if there's a better way to work in this functionality.

