### PR TITLE
fix: drop deprecated silent() from simple-git

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4470,6 +4470,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5780,6 +5787,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -10836,13 +10844,23 @@
       }
     },
     "simple-git": {
-      "version": "2.35.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.35.1.tgz",
-      "integrity": "sha512-Y5/hXf5ivfMziWRNGhVsbiG+1h4CkTW2qVC3dRidLuSZYAPFbLCPP1d7rgiL40lgRPhPTBuhVzNJAV9glWstEg==",
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.36.1.tgz",
+      "integrity": "sha512-bN18Ea/4IJgqgbZyE9VpVEUkAu9vyP0VWP7acP0CRC1p/N80GGJ0HhIVeFJsm8TdJLBowiJpdLesQuAZ5TFSKw==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "sisteransi": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "netrc": "^0.1.4",
     "ora": "^5.3.0",
     "preferences": "^2.0.2",
-    "simple-git": "^2.34.2"
+    "simple-git": "^2.36.1"
   },
   "devDependencies": {
     "@octokit/plugin-rest-endpoint-methods": "^4.10.2",

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -91,8 +91,7 @@ abstract class GitAdapter implements IRepoAdapter {
   protected abstract getRepositoryUrl(repo: IRepo): string;
 
   protected git(repo: IRepo): SimpleGit {
-    const git = simpleGit(this.getRepoDir(repo));
-    return git;
+    return simpleGit(this.getRepoDir(repo));
   }
 
   protected isShepherdCommitMessage(message: string): boolean {

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -38,7 +38,6 @@ abstract class GitAdapter implements IRepoAdapter {
       await this.git(repo).fetch('origin');
     } else {
       const git = simpleGit();
-      git.silent(true);
       await git.clone(repoPath, localPath, ['--depth', '1']);
     }
 
@@ -93,7 +92,6 @@ abstract class GitAdapter implements IRepoAdapter {
 
   protected git(repo: IRepo): SimpleGit {
     const git = simpleGit(this.getRepoDir(repo));
-    git.silent(true);
     return git;
   }
 


### PR DESCRIPTION
Recent versions of `simple-git` deprecated the `.silent()` API, which now spams the console with a deprecation notice whenever it's used:

```
simple-git deprecation notice: git.silent: logging should be configured using the `debug` library / `DEBUG` environment variable, this will be an error in version 3
```

This PR drops the use of that API. The logger is now silent by default, which is the behavior we want.