### PR TITLE
docs: Change the pr_message examples to use single-quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ hooks:
     - git log -1 --format=%cd | grep 2018 --silent # Only migrate things that have seen commits in 2018
   post_checkout: npm install
   apply: mv .eslintrc .eslintrc.json
-  pr_message: echo "Hey! This PR renames `.eslintrc` to `.eslintrc.json`"
+  pr_message: echo 'Hey! This PR renames `.eslintrc` to `.eslintrc.json`'
 ```
 
 Let's go through this line-by-line:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -226,7 +226,7 @@ We're almost done! Our last step is to open a pull request with these changes. T
 # shepherd.yml
 hooks:
   pr_message:
-    - echo "Hey! This PR renames `.eslintrc` to `.eslintrc.yml`"
+    - echo 'Hey! This PR renames `.eslintrc` to `.eslintrc.yml`'
 ```
 
 You can now open a pull request for your repos:
@@ -256,7 +256,7 @@ hooks:
   apply:
     - mv .eslintrc .eslintrc.yml
   pr_message:
-    - echo "Hey! This PR renames `.eslintrc` to `.eslintrc.yml`"
+    - echo 'Hey! This PR renames `.eslintrc` to `.eslintrc.yml`'
 ```
 
 And here are all the commands we used to apply this migration:


### PR DESCRIPTION
So the shell doesn't try to run the backtick-wrapped parts as commands.

To fix this essentially:
```
> echo "Hey! This PR renames `.eslintrc` to `.eslintrc.json`"
.eslintrc: command not found
.eslintrc.json: command not found
Hey! This PR renames  to
```

---

Also this is my first time using conventional-commits. Let me know if I messed anything up, or if I could do things better. 