### PR TITLE
chore: Bump @octokit/rest to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@octokit/plugin-retry": "^3.0.9",
     "@octokit/plugin-throttling": "^3.5.2",
-    "@octokit/rest": "^18.1.0",
+    "@octokit/rest": "^18.12.0",
     "@types/js-yaml": "^3.12.6",
     "chalk": "^4.1.0",
     "child-process-promise": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,7 +830,7 @@
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.0.0", "@octokit/rest@^18.1.0":
+"@octokit/rest@^18.0.0", "@octokit/rest@^18.12.0":
   version "18.12.0"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
   integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==


### PR DESCRIPTION
`yarn.lock` already had `@octokit/rest` at the latest version, but I want to ensure that Shepherd consumers get that version too - apparently that's important for our Octokit plugins to work correctly.