### PR TITLE
fix: Use custom GitHub token to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # This ensures our custom `GITHUB_TOKEN` is used by `semantic-release`
+          # instead of the default credentials. This is important for bypassing
+          # the branch protection rules that are configured for master.
+          # see https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Our few most recent commits to master have failed to publish because `semantic-release` couldn't push new versions to `master`. Per https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch, we should be setting `persist-credentials: false` during checkout so that our custom token (that can bypass branch protection restrictions) is used by `semantic-release`.