### PR TITLE
feat: added options to create pr from fork to upstream

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -29,7 +29,7 @@ interface IRepoAdapter {
 
   pushRepo(repo: IRepo, force: boolean): Promise<void>;
 
-  createPullRequest(repo: IRepo, message: string): Promise<void>;
+  createPullRequest(repo: IRepo, message: string, upstreamOwner: string): Promise<void>;
 
   getPullRequestStatus(repo: IRepo): Promise<string[]>;
 

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -74,7 +74,7 @@ abstract class GitAdapter implements IRepoAdapter {
     await this.git(repo).push('origin', 'HEAD', options);
   }
 
-  public abstract createPullRequest(repo: IRepo, message: string): Promise<void>;
+  public abstract createPullRequest(repo: IRepo, message: string, upstreamOwner: string): Promise<void>;
 
   public abstract getPullRequestStatus(repo: IRepo): Promise<string[]>;
 

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -199,7 +199,7 @@ describe('GithubAdapter', () => {
       service.listPullRequests.mockResolvedValue([]);
       const adapter = new GithubAdapter(context, service);
 
-      await adapter.createPullRequest(REPO, 'Test PR message');
+      await adapter.createPullRequest(REPO, 'Test PR message', 'NerdWallet');
 
       expect(service.listPullRequests).toBeCalledWith({
         owner: 'NerdWallet',
@@ -227,7 +227,7 @@ describe('GithubAdapter', () => {
         },
       ]);
       const adapter = new GithubAdapter(context, service);
-      await adapter.createPullRequest(REPO, 'Test PR message, part 2');
+      await adapter.createPullRequest(REPO, 'Test PR message, part 2', 'NerdWallet');
 
       expect(service.updatePullRequest).toBeCalledWith({
         owner: 'NerdWallet',
@@ -249,7 +249,7 @@ describe('GithubAdapter', () => {
         },
       ]);
       const adapter = new GithubAdapter(context, service);
-      await expect(adapter.createPullRequest(REPO, 'Test PR message, part 2')).rejects.toThrow();
+      await expect(adapter.createPullRequest(REPO, 'Test PR message, part 2', 'NerdWallet')).rejects.toThrow();
       expect(service.updatePullRequest).not.toBeCalled();
     });
   });

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -130,11 +130,17 @@ class GithubAdapter extends GitAdapter {
     await super.pushRepo(repo, force || shouldForce);
   }
 
-  public async createPullRequest(repo: IRepo, message: string): Promise<void> {
+  public async createPullRequest(repo: IRepo, message: string, upstreamOwner: string): Promise<void> {
     const {
       migration: { spec },
     } = this.migrationContext;
     const { owner, name, defaultBranch } = repo;
+
+    let baseOwner = owner;
+    
+    if(upstreamOwner) {
+      baseOwner = upstreamOwner;
+    }
 
     // Let's check if a PR already exists
     const pullRequests = await this.githubService.listPullRequests({
@@ -149,7 +155,7 @@ class GithubAdapter extends GitAdapter {
       if (pullRequest.state === 'open') {
         // A pull request exists and is open, let's update it
         await this.githubService.updatePullRequest({
-          owner,
+          owner: baseOwner,
           repo: name,
           pull_number: pullRequest.number,
           title: spec.title,
@@ -162,10 +168,11 @@ class GithubAdapter extends GitAdapter {
       }
     } else {
       // No PR yet - we have to create it
+  
       await this.githubService.createPullRequest({
-        owner,
+        owner: baseOwner,
         repo: name,
-        head: this.branchName,
+        head: `${owner}:${this.branchName}`,
         base: defaultBranch,
         title: spec.title,
         body: message,
@@ -273,6 +280,10 @@ class GithubAdapter extends GitAdapter {
       repo.owner,
       repo.name
     );
+  }
+
+  public getOwnerName(owner: string): string {
+    return owner;
   }
 
   public getBaseBranch(repo: IRepo): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ type CommandHandler = (context: IMigrationContext, options: any) => Promise<void
 
 interface ICliOptions {
   repos?: string[];
+  upstreamOwner: string;
 }
 
 const handleCommand =
@@ -76,6 +77,7 @@ const handleCommand =
 
       // The list of repos will be null if migration hasn't started yet
       migrationContext.migration.repos = await loadRepoList(migrationContext);
+      migrationContext.migration.upstreamOwner = options.upstreamOwner;
 
       await handler(migrationContext, options);
     } catch (e: any) {
@@ -94,10 +96,15 @@ const addReposOption = (command: program.Command) => {
   );
 };
 
+const addUpstreamOwnerOption = (command: program.Command) => {
+  return command.option('--upstreamOwner <upstreamOwner>', 'Upstream Owner can be passed incase of trying to raise PR from fork to upstream');
+}
+
 const addCommand = (name: string, description: string, repos: boolean, handler: CommandHandler) => {
   const subprogram = buildCommand(name, description);
   if (repos) {
     addReposOption(subprogram);
+    addUpstreamOwnerOption(subprogram);
   }
   subprogram.action(handleCommand(handler));
 };

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -5,7 +5,7 @@ import { generatePrMessageWithFooter } from '../util/generate-pr-message';
 
 export default async (context: IMigrationContext) => {
   const {
-    migration: { spec },
+    migration: { spec , upstreamOwner },
     logger,
   } = context;
 
@@ -31,7 +31,7 @@ export default async (context: IMigrationContext) => {
 
     const prSpinner = logger.spinner('Creating pull request');
     try {
-      await context.adapter.createPullRequest(repo, message);
+      await context.adapter.createPullRequest(repo, message, upstreamOwner);
       prSpinner.succeed('Pull request created');
     } catch (e: any) {
       logger.error(e);

--- a/src/migration-context.ts
+++ b/src/migration-context.ts
@@ -11,6 +11,7 @@ export interface IMigrationInfo {
   migrationDirectory: string;
   workingDirectory: string;
   repos: IRepo[] | null;
+  upstreamOwner: string;
   selectedRepos?: IRepo[];
 }
 


### PR DESCRIPTION
## Background

This PR adds a feature to enable use of Shepherd to raise a PR from a fork to upstream.  The feature is exposed via the `--upstreamOwner` CLI option.  When present with non-null value in the `pr` command, the PRs will be opened towards `${upstreamOwner}:{branchName}` for all in-scope repos.

It's not immediately obvious and so worth highlighting that the Shepherd `push` command does not require any changes to work as expected.  Just note that pushing changes is done relative to the remote and branch configuration as set during Shepherd checkout.