### PR TITLE
fix(lint): ignore linting on CHANGELOG.md file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules
 node_modules
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [2.2.0](https://github.com/NerdWalletOSS/shepherd/compare/v2.1.0...v2.2.0) (2024-01-09)
 
-
 ### Features
 
-* **gh-enterprise:** Add support for github enterprise servers ([#631](https://github.com/NerdWalletOSS/shepherd/issues/631)) ([509fe75](https://github.com/NerdWalletOSS/shepherd/commit/509fe75d4e41a2a8b47c89964e8cb2933fb3d077))
+- **gh-enterprise:** Add support for github enterprise servers ([#631](https://github.com/NerdWalletOSS/shepherd/issues/631)) ([509fe75](https://github.com/NerdWalletOSS/shepherd/commit/509fe75d4e41a2a8b47c89964e8cb2933fb3d077))
 
 # [2.1.0](https://github.com/NerdWalletOSS/shepherd/compare/v2.0.1...v2.1.0) (2023-10-03)
 


### PR DESCRIPTION
# Background

Eslint is enabled on CHANGELOG.md file.  There has been a recent change wherein either the linter or semantic-release changes result in a linting error.  In particular, items now leverage a `-` instead of `*` where linter rules are enforcing the use of the former, not the latter.

This change simply disables linting on this file.