### PR TITLE
fix(prettier): ignore CHANGELOG.md file when running prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 lib
 coverage
+CHANGELOG.md


### PR DESCRIPTION
# Background

Disabling prettier on CHANGELOG.md as this is unnecessary and breaks our CI.  If we feel strongly that we want to run prettier on this file, can always revisit.