### PR TITLE
feat(ts-node): BREAKING CHANGE execute ts files directly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       parserOptions: {
-        project: ['tsconfig.cjs.json'],
+        project: ['tsconfig.json'],
       },
     },
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+      - name: Setup ts-node
+        run: npm install -g ts-node
       - name: Get Npm cache directory path
         id: npm-cache-dir-path
         run: echo "::set-output name=dir::$(npm config get cache)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Built files
-lib/
-
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ For more high level context, this [blog post](https://www.nerdwallet.com/blog/en
 
 ## Getting started
 
-Install the Shepherd CLI:
+Install `ts-node` globally:
+
+```sh
+npm install ts-node
+```
+
+Install Shepherd CLI:
 
 ```sh
 npm install -g @nerdwallet/shepherd

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  coveragePathIgnorePatterns: ['\\.mock\\.ts$'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,14 @@
         "child-process-promise": "^2.2.1",
         "commander": "^11.1.0",
         "fs-extra": "^11.2.0",
-        "joi": "^17.11.0",
+        "joi": "^17.12.2",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "log-symbols": "^4.1.0",
         "netrc": "^0.1.4",
         "ora": "^5.4.1",
         "preferences": "^2.0.2",
-        "simple-git": "^3.22.0",
+        "simple-git": "^3.24.0",
         "ts-node": "^10.9.2"
       },
       "bin": {
@@ -33,25 +33,25 @@
       },
       "devDependencies": {
         "@octokit/plugin-rest-endpoint-methods": "^10.2.0",
-        "@octokit/types": "^12.4.0",
+        "@octokit/types": "^12.6.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@types/fs-extra": "^11.0.4",
-        "@types/jest": "^29.5.11",
-        "@types/lodash": "^4.14.202",
-        "@types/node": "^20.11.0",
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^7.0.0",
+        "@types/jest": "^29.5.12",
+        "@types/lodash": "^4.17.0",
+        "@types/node": "^20.12.2",
+        "@typescript-eslint/eslint-plugin": "^7.4.0",
+        "@typescript-eslint/parser": "^7.4.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "jest": "^29.7.0",
-        "prettier": "^3.2.2",
-        "semantic-release": "^23.0.0",
-        "ts-jest": "^29.1.1",
-        "typescript": "^5.3.3"
+        "prettier": "^3.2.5",
+        "semantic-release": "^23.0.6",
+        "ts-jest": "^29.1.2",
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3228,9 +3228,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001600",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
-      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+      "version": "1.0.30001603",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001603.tgz",
+      "integrity": "sha512-iL2iSS0eDILMb9n5yKQoTBim9jMZ0Yrk8g0N9K7UzYyWnfIKzXBZD5ngpM37ZcL/cv0Mli8XtVMRYMQAfFpi5Q==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,11 @@
         "netrc": "^0.1.4",
         "ora": "^5.4.1",
         "preferences": "^2.0.2",
-        "simple-git": "^3.22.0"
+        "simple-git": "^3.22.0",
+        "ts-node": "^10.9.2"
       },
       "bin": {
-        "shepherd": "lib/cli.js"
+        "shepherd": "src/cli.ts"
       },
       "devDependencies": {
         "@octokit/plugin-rest-endpoint-methods": "^10.2.0",
@@ -679,6 +680,26 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1229,7 +1250,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1246,8 +1266,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2227,6 +2246,26 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2357,7 +2396,6 @@
       "version": "20.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
       "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2595,7 +2633,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2612,10 +2649,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
@@ -2720,6 +2765,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3575,6 +3625,11 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "node_modules/cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
@@ -3775,6 +3830,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -3866,9 +3929,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.715",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
-      "integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
+      "version": "1.4.722",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.722.tgz",
+      "integrity": "sha512-5nLE0TWFFpZ80Crhtp4pIp8LXCztjYX41yUcV6b+bKR2PqzjskTMOOlBi1VjBHlvHwS+4gar7kNKOrsbsewEZQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4090,9 +4153,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
-      "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4134,11 +4197,11 @@
         "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.9",
         "string.prototype.trimend": "^1.0.8",
-        "string.prototype.trimstart": "^1.0.7",
+        "string.prototype.trimstart": "^1.0.8",
         "typed-array-buffer": "^1.0.2",
         "typed-array-byte-length": "^1.0.1",
         "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.5",
+        "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.15"
       },
@@ -6857,8 +6920,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7199,13 +7261,6 @@
         "write-file-atomic"
       ],
       "dev": true,
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^7.2.1",
@@ -11432,9 +11487,9 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.23.0.tgz",
-      "integrity": "sha512-P9ggTW8vb/21CAL/AmnACAhqBDfnqSSZVpV7WuFtsFR9HLunf5IqQvk+OXAQTfkcZep8pKnt3DV3o7w3TegEkQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.24.0.tgz",
+      "integrity": "sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -12044,6 +12099,48 @@
         }
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -12187,7 +12284,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
       "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12227,8 +12323,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -12331,6 +12426,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -12516,6 +12616,14 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -29,28 +29,6 @@
     "prepublishOnly": "yarn test && yarn build",
     "test": "jest --coverage src/"
   },
-  "jest": {
-    "coveragePathIgnorePatterns": [
-      "\\.mock\\.ts$"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "transform": {
-      "^.+\\.tsx?$": [
-        "ts-jest",
-        {
-          "tsconfig": "tsconfig.json"
-        }
-      ]
-    }
-  },
   "files": [
     "lib"
   ],
@@ -64,37 +42,37 @@
     "child-process-promise": "^2.2.1",
     "commander": "^11.1.0",
     "fs-extra": "^11.2.0",
-    "joi": "^17.11.0",
+    "joi": "^17.12.2",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "log-symbols": "^4.1.0",
     "netrc": "^0.1.4",
     "ora": "^5.4.1",
     "preferences": "^2.0.2",
-    "simple-git": "^3.22.0",
+    "simple-git": "^3.24.0",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {
     "@octokit/plugin-rest-endpoint-methods": "^10.2.0",
-    "@octokit/types": "^12.4.0",
+    "@octokit/types": "^12.6.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/fs-extra": "^11.0.4",
-    "@types/jest": "^29.5.11",
-    "@types/lodash": "^4.14.202",
-    "@types/node": "^20.11.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^7.0.0",
+    "@types/jest": "^29.5.12",
+    "@types/lodash": "^4.17.0",
+    "@types/node": "^20.12.2",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
     "conventional-changelog-conventionalcommits": "^7.0.2",
-    "eslint": "^8.56.0",
+    "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "jest": "^29.7.0",
-    "prettier": "^3.2.2",
-    "semantic-release": "^23.0.0",
-    "ts-jest": "^29.1.1",
-    "typescript": "^5.3.3"
+    "prettier": "^3.2.5",
+    "semantic-release": "^23.0.6",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.3"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "author": "Nathan Walters",
   "main": "./lib/cli.js",
   "bin": {
-    "shepherd": "./lib/cli.js"
+    "shepherd": "./src/cli.ts"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.cjs.json",
+    "build": "tsc -p tsconfig.json",
     "build:watch": "yarn build --watch",
     "fix-lint": "eslint src/**/*.ts --fix && prettier --write .",
     "lint": "eslint src/**/*.ts && prettier --check .",
@@ -46,7 +46,7 @@
       "^.+\\.tsx?$": [
         "ts-jest",
         {
-          "tsconfig": "tsconfig.cjs.json"
+          "tsconfig": "tsconfig.json"
         }
       ]
     }
@@ -71,7 +71,8 @@
     "netrc": "^0.1.4",
     "ora": "^5.4.1",
     "preferences": "^2.0.2",
-    "simple-git": "^3.22.0"
+    "simple-git": "^3.22.0",
+    "ts-node": "^10.9.2"
   },
   "devDependencies": {
     "@octokit/plugin-rest-endpoint-methods": "^10.2.0",

--- a/renovate.json
+++ b/renovate.json
@@ -19,19 +19,18 @@
   "masterIssue": true,
   "masterIssueAutoclose": true,
   "node": {
-    "supportPolicy": [10, 12, 14],
+    "supportPolicy": [18, 20],
     "semanticCommitScope": "github",
     "automerge": true
   },
   "packageRules": [
     {
-      "description": "Auto update dev dependencies",
-      "depTypeList": ["devDependencies"],
-      "automerge": true
+      "description": "Do not auto update major types dependencies",
+      "updateTypes": ["major"],
+      "automerge": false
     },
     {
-      "description": "Auto update non-major types dev dependencies",
-      "packagePatterns": ["^@types/"],
+      "description": "Auto update non-major types dependencies",
       "updateTypes": ["minor", "patch"],
       "stabilityDays": 0
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node
 
 import { Command } from 'commander';
 import fs from 'fs-extra';

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -4,6 +4,7 @@ import { retry } from '@octokit/plugin-retry';
 import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
 import { throttling } from '@octokit/plugin-throttling';
 import _ from 'lodash';
+//@ts-ignore
 import netrc from 'netrc';
 
 import { IMigrationContext } from '../migration-context';

--- a/src/util/exec-in-repo.ts
+++ b/src/util/exec-in-repo.ts
@@ -1,3 +1,4 @@
+//@ts-ignore
 import { ChildProcessPromise, spawn } from 'child-process-promise';
 import { ChildProcess } from 'child_process';
 import { IRepo } from '../adapters/base';

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,6 +1,6 @@
 {
   // extend your base config to share compilerOptions, etc
-  "extends": "./tsconfig.cjs.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     // ensure that nobody can accidentally use this config for a build
     "noEmit": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,13 @@
     "rootDir": "./src",
     "removeComments": false,
     "strict": true,
+    "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "CommonJS",
+    "target": "ESNext",
+    "module": "NodeNext",
     "allowJs": false,
     "declaration": true,
-    "sourceMap": true,
-    "outDir": "./lib",
     "rootDir": "./src",
     "removeComments": false,
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
BREAKING CHANGE
## Background
The motivation behind this change is to explore what is possible with TypeScript (TS).  Whether or not we actually want to move to executing TS directly is still an open question that comes with non-trivial tradeoffs.  For example,
* We take a performance hit in executing TS directly via ts-node, however, if we were to do so within a Deno environment, the performance is comparable to javascript.
* We improve developer experience and workflow as developers do not need to worry about transpilation setup and issues.  For example, upgrading to latest ora, commander, and log-symbols is non-trivial and most of the complexity is a result of the new major versions of those packages being of type module (esm) vs commonjs.  
* We require global installation of ts-node which is not something customers needed to worry about or even think about previously.

## Changes
Currently we transpile ts files to js, as files are executed in NodeJS environment which doesn't support direct execution of ts files.  These changes enable ts files to be executed directly through ts-node.

This PR also contains:
* updates to renovate configurations.
* move of jest configuration to standalone file.

## Notes
1. Assumes ts-node is installed globally.
2. ts-node is widely adopted in the NodeJS and TS communities for executing TS code directly without requiring a separate compilation step. 
    - Download count on npm: 19.5+M/week
    - Last update: 4 months ago

## Alternatives
1. Instead of ts-node, use Deno
