### PR TITLE
feat: Add https auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install -g @nerdwallet/shepherd
 If using GitHub Enterprise, ensure the following environment variables are exported:
 
 ```
-export SHEPHERD_GITHUB_ENTERPRISE_BASE_URL={company_github_enterprise_base_url} # e.g., api.github.com
+export SHEPHERD_GITHUB_ENTERPRISE_BASE_URL={company_github_enterprise_base_url} # e.g., github.com
 export SHEPHERD_GITHUB_ENTERPRISE_URL={company_github_enterprise_url} # e.g., api.github.com/api/v3
 ```
 

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -268,17 +268,17 @@ describe('GithubAdapter', () => {
 
     it('returns the SSH URL, when not given a protocol', () => {
       delete process.env.SHEPHERD_GITHUB_PROTOCOL;
-      expect(adapter['getRepositoryUrl'](repo)).toBe('git@api.github.com:NerdWallet/shepherd.git');
+      expect(adapter['getRepositoryUrl'](repo)).toBe('git@github.com:NerdWallet/shepherd.git');
     });
 
     it('returns the SSH URL, when given protocol=ssh', () => {
       process.env.SHEPHERD_GITHUB_PROTOCOL = 'ssh';
-      expect(adapter['getRepositoryUrl'](repo)).toBe('git@api.github.com:NerdWallet/shepherd.git');
+      expect(adapter['getRepositoryUrl'](repo)).toBe('git@github.com:NerdWallet/shepherd.git');
     });
 
     it('returns the HTTPS URL when given protocol=https', () => {
       process.env.SHEPHERD_GITHUB_PROTOCOL = 'https';
-      expect(adapter['getRepositoryUrl'](repo)).toBe('https://api.github.com/NerdWallet/shepherd.git');
+      expect(adapter['getRepositoryUrl'](repo)).toBe('https://github.com/NerdWallet/shepherd.git');
     });
 
     it('throws on unexpected protocols', () => {

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -255,4 +255,35 @@ describe('GithubAdapter', () => {
       expect(service.updatePullRequest).not.toBeCalled();
     });
   });
+
+  describe('getRepositoryUrl', () => {
+    const context = mockMigrationContext();
+    const octokit = {} as any as Octokit;
+    const service: any = new GithubService(context, octokit);
+    const adapter = new GithubAdapter(context, service);
+    const repo = {
+      owner: 'NerdWallet',
+      name: 'shepherd',
+    };
+
+    it('returns the SSH URL, when not given a protocol', () => {
+      delete process.env.SHEPHERD_GITHUB_PROTOCOL;
+      expect(adapter['getRepositoryUrl'](repo)).toBe('git@api.github.com:NerdWallet/shepherd.git');
+    });
+
+    it('returns the SSH URL, when given protocol=ssh', () => {
+      process.env.SHEPHERD_GITHUB_PROTOCOL = 'ssh';
+      expect(adapter['getRepositoryUrl'](repo)).toBe('git@api.github.com:NerdWallet/shepherd.git');
+    });
+
+    it('returns the HTTPS URL when given protocol=https', () => {
+      process.env.SHEPHERD_GITHUB_PROTOCOL = 'https';
+      expect(adapter['getRepositoryUrl'](repo)).toBe('https://api.github.com/NerdWallet/shepherd.git');
+    });
+
+    it('throws on unexpected protocols', () => {
+      process.env.SHEPHERD_GITHUB_PROTOCOL = 'not-a-protocol';
+      expect(() => adapter['getRepositoryUrl'](repo)).toThrow("Unknown protocol not-a-protocol. Valid values are 'ssh' and 'https'");
+    });
+  });
 });

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -305,7 +305,7 @@ class GithubAdapter extends GitAdapter {
   }
 
   protected getRepositoryUrl(repo: IRepo): string {
-    const gitHubEnterpriseBaseUrl = process.env.SHEPHERD_GITHUB_ENTERPRISE_BASE_URL ?? 'api.github.com';
+    const gitHubEnterpriseBaseUrl = process.env.SHEPHERD_GITHUB_ENTERPRISE_BASE_URL ?? 'github.com';
     const githubProtocol = process.env.SHEPHERD_GITHUB_PROTOCOL ?? 'ssh';
 
     if (githubProtocol === 'ssh') {

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -8,10 +8,6 @@ import { IEnvironmentVariables, IRepo } from './base';
 import GitAdapter from './git';
 import GithubService from '../services/github';
 
-const { SHEPHERD_GITHUB_ENTERPRISE_BASE_URL } = process.env;
-
-const gitHubEnterpriseBaseUrl = SHEPHERD_GITHUB_ENTERPRISE_BASE_URL || 'api.github.com';
-
 enum SafetyStatus {
   Success,
   PullRequestExisted,
@@ -309,7 +305,16 @@ class GithubAdapter extends GitAdapter {
   }
 
   protected getRepositoryUrl(repo: IRepo): string {
-    return `git@${gitHubEnterpriseBaseUrl}:${repo.owner}/${repo.name}.git`;
+    const gitHubEnterpriseBaseUrl = process.env.SHEPHERD_GITHUB_ENTERPRISE_BASE_URL ?? 'api.github.com';
+    const githubProtocol = process.env.SHEPHERD_GITHUB_PROTOCOL ?? 'ssh';
+
+    if (githubProtocol === 'ssh') {
+      return `git@${gitHubEnterpriseBaseUrl}:${repo.owner}/${repo.name}.git`;
+    } else if (githubProtocol === 'https') {
+      return `https://${gitHubEnterpriseBaseUrl}/${repo.owner}/${repo.name}.git`;
+    } else {
+      throw new Error(`Unknown protocol ${githubProtocol}. Valid values are 'ssh' and 'https'`);
+    }
   }
 
   private async checkActionSafety(repo: IRepo): Promise<SafetyStatus> {


### PR DESCRIPTION
Shepherd currently uses ssh git urls to clone repositories.
This assumes that ssh auth is available in the environment for all repositories being cloned.

We are trying to use GitHub Actions to run Shepherd, with a GitHub App providing authentication.
This works for the API (we can have the GitHub App's API token get used by shepherd), but GitHub Apps do not have SSH keys associated with them to allow git pushes over ssh.

They can however use http authentication with their GitHub token to perform git pushes, which this PR allows for using (`SHEPHERD_GITHUB_ENTERPRISE_BASE_URL=x-access-token:${GITHUB_PAT}@github.com`)