### PR TITLE
fix(env-var): respect SHEPHERD_BASE_BRANCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,10 @@ hooks:
 ### Fields
 
 - `id`:
-
   - **Description**: Specifies a unique identifier for this migration.
   - **Usage**: Used as a branch name for the migration and internally by Shepherd to track migration state.
 
 - `title`:
-
   - **Description**: A title for the migration.
   - **Usage**: Used as the commit message.
 
@@ -109,17 +107,14 @@ hooks:
 Hooks define the core functionality of a migration in Shepherd.
 
 - `should_migrate`:
-
   - **Description**: Commands to determine if a repo requires migration.
   - **Behavior**: Non-zero exit values indicate the repo should not be migrated.
 
 - `post_checkout`:
-
   - **Description**: Commands executed after a repo passes `should_migrate` checks.
   - **Usage**: Ideal for one-time setup actions per repo, like installing dependencies.
 
 - `apply`:
-
   - **Description**: Commands that perform the actual migration.
   - **Note**: This can range from simple to complex sequences, depending on migration needs.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <img alt="Illustration of a sheep" width=160 align=right src="images/shepherd-logo.png">
 
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/NerdWalletOSS/shepherd/release.yml?style=flat-square)](https://github.com/NerdWalletOSS/shepherd/actions)
 [![semantic-release: conventionalcommits](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 ![npm version](https://img.shields.io/npm/v/@nerdwallet/shepherd.svg?style=flat-square)

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,11 +56,7 @@
         "prettier": "^3.3.3",
         "semantic-release": "^24.1.2",
         "ts-jest": "^29.2.5",
-<<<<<<< HEAD
         "typescript": "5.9",
-=======
-        "typescript": "5.8",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "typescript-eslint": "^8.8.0"
       }
     },
@@ -104,39 +100,22 @@
       }
     },
     "node_modules/@babel/core": {
-<<<<<<< HEAD
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
-=======
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-<<<<<<< HEAD
-        "@babel/generator": "^7.27.3",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.4",
-        "@babel/parser": "^7.27.4",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.3",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.27.4",
-        "@babel/types": "^7.27.3",
-=======
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -152,14 +131,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -199,18 +178,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.27.1",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/traverse": "^7.28.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -294,15 +273,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -415,52 +394,42 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-      "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
+      "integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-<<<<<<< HEAD
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
-=======
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-<<<<<<< HEAD
-        "@babel/types": "^7.27.6"
-=======
         "@babel/types": "^7.28.2"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.28.2"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -537,14 +506,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-      "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
+      "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -940,13 +909,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-      "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
+      "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.28.3",
         "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
@@ -957,9 +926,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.0.tgz",
-      "integrity": "sha512-IjM1IoJNw72AZFlj33Cu8X0q2XK/6AaVC3jQu+cgQ5lThWD5ajnuUAml80dqRmOhmPkTH8uAwnpMu9Rvj0LTRA==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.3.tgz",
+      "integrity": "sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -968,7 +937,7 @@
         "@babel/helper-globals": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.28.0"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1498,15 +1467,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-<<<<<<< HEAD
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
-      "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
-=======
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
-      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.3.tgz",
+      "integrity": "sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1634,15 +1597,6 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-<<<<<<< HEAD
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
-      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-=======
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
       "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
@@ -1650,7 +1604,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "@babel/helper-create-class-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
@@ -1731,9 +1684,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.0.tgz",
-      "integrity": "sha512-VmaxeGOwuDqzLl5JUkIRM1X2Qu2uKGxHEQWh+cvvbl7JuJRgKGJSfsEF/bUaxFhJl/XAyxBe7q7qSuTbKFuCyg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
+      "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1745,7 +1698,7 @@
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
         "@babel/plugin-syntax-import-assertions": "^7.27.1",
         "@babel/plugin-syntax-import-attributes": "^7.27.1",
@@ -1756,8 +1709,8 @@
         "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
         "@babel/plugin-transform-block-scoping": "^7.28.0",
         "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.0",
+        "@babel/plugin-transform-class-static-block": "^7.28.3",
+        "@babel/plugin-transform-classes": "^7.28.3",
         "@babel/plugin-transform-computed-properties": "^7.27.1",
         "@babel/plugin-transform-destructuring": "^7.28.0",
         "@babel/plugin-transform-dotall-regex": "^7.27.1",
@@ -1789,7 +1742,7 @@
         "@babel/plugin-transform-private-methods": "^7.27.1",
         "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.28.0",
+        "@babel/plugin-transform-regenerator": "^7.28.3",
         "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
         "@babel/plugin-transform-reserved-words": "^7.27.1",
         "@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -1866,18 +1819,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/types": "^7.28.2",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1885,15 +1838,9 @@
       }
     },
     "node_modules/@babel/types": {
-<<<<<<< HEAD
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
-=======
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
       "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1923,37 +1870,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-<<<<<<< HEAD
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
-      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
-=======
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
       "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-<<<<<<< HEAD
-        "@emnapi/wasi-threads": "1.0.2",
-=======
         "@emnapi/wasi-threads": "1.0.4",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-<<<<<<< HEAD
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
-=======
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1962,15 +1893,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-<<<<<<< HEAD
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
-      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
-=======
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
       "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2047,9 +1972,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2057,9 +1982,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2141,15 +2066,9 @@
       }
     },
     "node_modules/@eslint/js": {
-<<<<<<< HEAD
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
-=======
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
-      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
+      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2170,13 +2089,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -2803,9 +2722,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2824,22 +2743,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-<<<<<<< HEAD
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-=======
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2863,26 +2776,16 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-<<<<<<< HEAD
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
-      "integrity": "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==",
-=======
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
-<<<<<<< HEAD
-        "@tybys/wasm-util": "^0.9.0"
-=======
         "@tybys/wasm-util": "^0.10.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2933,15 +2836,9 @@
       }
     },
     "node_modules/@octokit/core": {
-<<<<<<< HEAD
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
-      "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
-=======
       "version": "6.1.6",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
@@ -3125,15 +3022,9 @@
       }
     },
     "node_modules/@octokit/request": {
-<<<<<<< HEAD
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz",
-      "integrity": "sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==",
-=======
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
       "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^10.1.4",
@@ -3347,9 +3238,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.3.tgz",
-      "integrity": "sha512-T2fKUyFkHHkUNa5XNmcsEcDPuG23hwBKptfUVcFXDVG2cSjXXZYDOfVYwfouqbWo/8UefotLaoGfQeK+k3ep6A==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.4.tgz",
+      "integrity": "sha512-fU/nLSjkp9DmB0h7FVO5imhhWJMvq2LjD4+3lz3ZAzpDLY9+KYwC+trJ+g7LbZeJv9y3L9fSFSg2DduUpiT6bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3388,15 +3279,9 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/core": {
-<<<<<<< HEAD
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.2.tgz",
-      "integrity": "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==",
-=======
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
       "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3449,15 +3334,9 @@
       "license": "MIT"
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
-<<<<<<< HEAD
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.0.1.tgz",
-      "integrity": "sha512-m1KvHlueScy4mQJWvFDCxFBTIdXS0K1SgFGLmqHyX90mZdCIv6gWBbKRhatxRjhGlONuTK/hztYdaqrTXcFZdQ==",
-=======
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
       "integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3506,15 +3385,9 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/request": {
-<<<<<<< HEAD
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.2.tgz",
-      "integrity": "sha512-iYj4SJG/2bbhh+iIpFmG5u49DtJ4lipQ+aPakjL9OKpsGY93wM8w06gvFbEQxcMsZcCvk5th5KkIm2m8o14aWA==",
-=======
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
       "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4034,15 +3907,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-<<<<<<< HEAD
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
-      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
-=======
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
       "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4086,13 +3953,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/estree": {
@@ -4199,15 +4066,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-<<<<<<< HEAD
-      "version": "22.17.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
-      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
-=======
-      "version": "22.16.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
-      "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4246,30 +4107,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-<<<<<<< HEAD
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
-      "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
-=======
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz",
-      "integrity": "sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.40.0.tgz",
+      "integrity": "sha512-w/EboPlBwnmOBtRbiOvzjD+wdiZdgFeo17lkltrtn7X37vagKKWJABvyfsJXTlHe6XBzugmYgd4A4nW+k8Mixw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-<<<<<<< HEAD
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/type-utils": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
-=======
-        "@typescript-eslint/scope-manager": "8.38.0",
-        "@typescript-eslint/type-utils": "8.38.0",
-        "@typescript-eslint/utils": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/scope-manager": "8.40.0",
+        "@typescript-eslint/type-utils": "8.40.0",
+        "@typescript-eslint/utils": "8.40.0",
+        "@typescript-eslint/visitor-keys": "8.40.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -4283,41 +4131,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
-        "@typescript-eslint/parser": "^8.39.0",
+        "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
-      "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.40.0.tgz",
+      "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
-=======
-        "@typescript-eslint/parser": "^8.38.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
-      "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.38.0",
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/scope-manager": "8.40.0",
+        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/typescript-estree": "8.40.0",
+        "@typescript-eslint/visitor-keys": "8.40.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4329,33 +4158,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.0.tgz",
-      "integrity": "sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.40.0.tgz",
+      "integrity": "sha512-/A89vz7Wf5DEXsGVvcGdYKbVM9F7DyFXj52lNYUDS1L9yJfqjW/fIp5PgMuEJL/KeqVTe2QSbXAGUZljDUpArw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.39.0",
-        "@typescript-eslint/types": "^8.39.0",
-=======
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.38.0.tgz",
-      "integrity": "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.38.0",
-        "@typescript-eslint/types": "^8.38.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/tsconfig-utils": "^8.40.0",
+        "@typescript-eslint/types": "^8.40.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4366,33 +4180,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.0.tgz",
-      "integrity": "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.40.0.tgz",
+      "integrity": "sha512-y9ObStCcdCiZKzwqsE8CcpyuVMwRouJbbSrNuThDpv16dFAj429IkM6LNb1dZ2m7hK5fHyzNcErZf7CEeKXR4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0"
-=======
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.38.0.tgz",
-      "integrity": "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/visitor-keys": "8.40.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4403,15 +4202,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-<<<<<<< HEAD
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
-      "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
-=======
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.38.0.tgz",
-      "integrity": "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.40.0.tgz",
+      "integrity": "sha512-jtMytmUaG9d/9kqSl/W3E3xaWESo4hFDxAIHGVW/WKKtQhesnRIJSAJO6XckluuJ6KDB5woD1EiqknriCtAmcw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4422,35 +4215,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.0.tgz",
-      "integrity": "sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.40.0.tgz",
+      "integrity": "sha512-eE60cK4KzAc6ZrzlJnflXdrMqOBaugeukWICO2rB0KNvwdIMaEaYiywwHMzA1qFpTxrLhN9Lp4E/00EgWcD3Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
-=======
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.38.0.tgz",
-      "integrity": "sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0",
-        "@typescript-eslint/utils": "8.38.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/typescript-estree": "8.40.0",
+        "@typescript-eslint/utils": "8.40.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -4463,23 +4240,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
-      "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
-=======
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
-      "integrity": "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.40.0.tgz",
+      "integrity": "sha512-ETdbFlgbAmXHyFPwqUIYrfc12ArvpBhEVgGAxVYSwli26dn8Ko+lIo4Su9vI9ykTZdJn+vJprs/0eZU0YMAEQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4491,29 +4258,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-<<<<<<< HEAD
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
-      "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.40.0.tgz",
+      "integrity": "sha512-k1z9+GJReVVOkc1WfVKs1vBrR5MIKKbdAjDTPvIK3L8De6KbFfPFt6BKpdkdk7rZS2GtC/m6yI5MYX+UsuvVYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.39.0",
-        "@typescript-eslint/tsconfig-utils": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
-=======
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.38.0.tgz",
-      "integrity": "sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.38.0",
-        "@typescript-eslint/tsconfig-utils": "8.38.0",
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/visitor-keys": "8.38.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/project-service": "8.40.0",
+        "@typescript-eslint/tsconfig-utils": "8.40.0",
+        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/visitor-keys": "8.40.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -4529,11 +4283,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
-=======
-        "typescript": ">=4.8.4 <5.9.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -4550,28 +4300,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-<<<<<<< HEAD
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
-      "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
-=======
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.38.0.tgz",
-      "integrity": "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.40.0.tgz",
+      "integrity": "sha512-Cgzi2MXSZyAUOY+BFwGs17s7ad/7L+gKt6Y8rAVVWS+7o6wrjeFN4nVfTpbE25MNcxyJ+iYUXflbs2xR9h4UBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-<<<<<<< HEAD
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0"
-=======
-        "@typescript-eslint/scope-manager": "8.38.0",
-        "@typescript-eslint/types": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/scope-manager": "8.40.0",
+        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/typescript-estree": "8.40.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4582,31 +4320,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.0.tgz",
-      "integrity": "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.40.0.tgz",
+      "integrity": "sha512-8CZ47QwalyRjsypfwnbI3hKy5gJDPmrkLjkgMxhi0+DZZ2QNx2naS6/hWoVYUHU7LU2zleF68V9miaVZvhFfTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-=======
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.38.0.tgz",
-      "integrity": "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.38.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/types": "8.40.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4631,15 +4355,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.9.0.tgz",
-      "integrity": "sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
       "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm"
       ],
@@ -4651,15 +4369,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.9.0.tgz",
-      "integrity": "sha512-sG1NHtgXtX8owEkJ11yn34vt0Xqzi3k9TJ8zppDmyG8GZV4kVWw44FHwKwHeEFl07uKPeC4ZoyuQaGh5ruJYPA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
       "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4671,15 +4383,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.9.0.tgz",
-      "integrity": "sha512-nJ9z47kfFnCxN1z/oYZS7HSNsFh43y2asePzTEZpEvK7kGyuShSl3RRXnm/1QaqFL+iP+BjMwuB+DYUymOkA5A==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
       "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4691,15 +4397,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.9.0.tgz",
-      "integrity": "sha512-TK+UA1TTa0qS53rjWn7cVlEKVGz2B6JYe0C++TdQjvWYIyx83ruwh0wd4LRxYBM5HeuAzXcylA9BH2trARXJTw==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
       "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4711,15 +4411,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.9.0.tgz",
-      "integrity": "sha512-6uZwzMRFcD7CcCd0vz3Hp+9qIL2jseE/bx3ZjaLwn8t714nYGwiE84WpaMCYjU+IQET8Vu/+BNAGtYD7BG/0yA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
       "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4731,15 +4425,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.9.0.tgz",
-      "integrity": "sha512-bPUBksQfrgcfv2+mm+AZinaKq8LCFvt5PThYqRotqSuuZK1TVKkhbVMS/jvSRfYl7jr3AoZLYbDkItxgqMKRkg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
       "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm"
       ],
@@ -4751,15 +4439,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.9.0.tgz",
-      "integrity": "sha512-uT6E7UBIrTdCsFQ+y0tQd3g5oudmrS/hds5pbU3h4s2t/1vsGWbbSKhBSCD9mcqaqkBwoqlECpUrRJCmldl8PA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
       "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm"
       ],
@@ -4771,15 +4453,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.9.0.tgz",
-      "integrity": "sha512-vdqBh911wc5awE2bX2zx3eflbyv8U9xbE/jVKAm425eRoOVv/VseGZsqi3A3SykckSpF4wSROkbQPvbQFn8EsA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
       "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4791,15 +4467,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.9.0.tgz",
-      "integrity": "sha512-/8JFZ/SnuDr1lLEVsxsuVwrsGquTvT51RZGvyDB/dOK3oYK2UqeXzgeyq6Otp8FZXQcEYqJwxb9v+gtdXn03eQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
       "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4811,15 +4481,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.9.0.tgz",
-      "integrity": "sha512-FkJjybtrl+rajTw4loI3L6YqSOpeZfDls4SstL/5lsP2bka9TiHUjgMBjygeZEis1oC8LfJTS8FSgpKPaQx2tQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
       "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "ppc64"
       ],
@@ -4831,15 +4495,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.9.0.tgz",
-      "integrity": "sha512-w/NZfHNeDusbqSZ8r/hp8iL4S39h4+vQMc9/vvzuIKMWKppyUGKm3IST0Qv0aOZ1rzIbl9SrDeIqK86ZpUK37w==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
       "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "riscv64"
       ],
@@ -4851,15 +4509,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.9.0.tgz",
-      "integrity": "sha512-bEPBosut8/8KQbUixPry8zg/fOzVOWyvwzOfz0C0Rw6dp+wIBseyiHKjkcSyZKv/98edrbMknBaMNJfA/UEdqw==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
       "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "riscv64"
       ],
@@ -4871,15 +4523,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.9.0.tgz",
-      "integrity": "sha512-LDtMT7moE3gK753gG4pc31AAqGUC86j3AplaFusc717EUGF9ZFJ356sdQzzZzkBk1XzMdxFyZ4f/i35NKM/lFA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
       "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "s390x"
       ],
@@ -4891,15 +4537,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.9.0.tgz",
-      "integrity": "sha512-WmFd5KINHIXj8o1mPaT8QRjA9HgSXhN1gl9Da4IZihARihEnOylu4co7i/yeaIpcfsI6sYs33cNZKyHYDh0lrA==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
       "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4911,15 +4551,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.9.0.tgz",
-      "integrity": "sha512-CYuXbANW+WgzVRIl8/QvZmDaZxrqvOldOwlbUjIM4pQ46FJ0W5cinJ/Ghwa/Ng1ZPMJMk1VFdsD/XwmCGIXBWg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
       "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4931,15 +4565,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.9.0.tgz",
-      "integrity": "sha512-6Rp2WH0OoitMYR57Z6VE8Y6corX8C6QEMWLgOV6qXiJIeZ1F9WGXY/yQ8yDC4iTraotyLOeJ2Asea0urWj2fKQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
       "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "wasm32"
       ],
@@ -4954,15 +4582,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.9.0.tgz",
-      "integrity": "sha512-rknkrTRuvujprrbPmGeHi8wYWxmNVlBoNW8+4XF2hXUnASOjmuC9FNF1tGbDiRQWn264q9U/oGtixyO3BT8adQ==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
       "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4974,15 +4596,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.9.0.tgz",
-      "integrity": "sha512-Ceymm+iBl+bgAICtgiHyMLz6hjxmLJKqBim8tDzpX61wpZOx2bPK6Gjuor7I2RiUynVjvvkoRIkrPyMwzBzF3A==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
       "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "ia32"
       ],
@@ -4994,15 +4610,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.0.tgz",
-      "integrity": "sha512-k59o9ZyeyS0hAlcaKFezYSH2agQeRFEB7KoQLXl3Nb3rgkqT1NY9Vwy+SqODiLmYnEjxWJVRE/yq2jFVqdIxZw==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
       "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -5037,15 +4647,9 @@
       }
     },
     "node_modules/agent-base": {
-<<<<<<< HEAD
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-=======
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5100,9 +4704,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5287,16 +4891,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5454,9 +5048,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5477,7 +5071,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -5540,15 +5134,9 @@
       }
     },
     "node_modules/browserslist": {
-<<<<<<< HEAD
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
-=======
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "4.25.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
+      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
       "dev": true,
       "funding": [
         {
@@ -5566,13 +5154,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
-=======
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "caniuse-lite": "^1.0.30001735",
+        "electron-to-chromium": "^1.5.204",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -5684,15 +5267,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-<<<<<<< HEAD
-      "version": "1.0.30001723",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
-      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
-=======
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
       "dev": true,
       "funding": [
         {
@@ -5711,9 +5288,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
+      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -6099,15 +5676,9 @@
       }
     },
     "node_modules/conventional-changelog-writer": {
-<<<<<<< HEAD
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.1.0.tgz",
-      "integrity": "sha512-dpC440QnORNCO81XYuRRFOLCsjKj4W7tMkUIn3lR6F/FAaJcWLi7iCj6IcEvSQY2zw6VUgwUKd5DEHKEWrpmEQ==",
-=======
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
       "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6183,23 +5754,13 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-<<<<<<< HEAD
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
-      "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
+      "integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.25.0"
-=======
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
-      "integrity": "sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.25.1"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "browserslist": "^4.25.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6583,33 +6144,10 @@
         "readable-stream": "^2.0.2"
       }
     },
-<<<<<<< HEAD
     "node_modules/electron-to-chromium": {
-      "version": "1.5.167",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
-      "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
-=======
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.191",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
-      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "1.5.208",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.208.tgz",
+      "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7034,31 +6572,20 @@
       }
     },
     "node_modules/eslint": {
-<<<<<<< HEAD
-      "version": "9.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-      "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
-=======
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
-      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.34.0.tgz",
+      "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.15.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-<<<<<<< HEAD
-        "@eslint/js": "9.32.0",
-        "@eslint/plugin-kit": "^0.3.4",
-=======
-        "@eslint/js": "9.31.0",
-        "@eslint/plugin-kit": "^0.3.1",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@eslint/js": "9.34.0",
+        "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -7122,24 +6649,14 @@
       }
     },
     "node_modules/eslint-import-context": {
-<<<<<<< HEAD
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.8.tgz",
-      "integrity": "sha512-bq+F7nyc65sKpZGT09dY0S0QrOnQtuDVIfyTGQ8uuvtMIF7oHp6CEP3mouN0rrnYF3Jqo6Ke0BfU/5wASZue1w==",
-=======
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
       "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-tsconfig": "^4.10.1",
-<<<<<<< HEAD
-        "stable-hash-x": "^0.1.1"
-=======
         "stable-hash-x": "^0.2.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -7213,19 +6730,6 @@
         }
       }
     },
-<<<<<<< HEAD
-    "node_modules/eslint-import-resolver-typescript/node_modules/stable-hash-x": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
-      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-=======
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
@@ -7810,32 +7314,6 @@
         "node": ">=16.0.0"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7942,9 +7420,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -9299,9 +8777,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9312,85 +8790,6 @@
         "node": ">=8"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/jake/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/java-properties": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -10553,9 +9952,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -10997,15 +10396,9 @@
       }
     },
     "node_modules/napi-postinstall": {
-<<<<<<< HEAD
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
-      "integrity": "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==",
-=======
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
-      "integrity": "sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -14489,15 +13882,9 @@
       }
     },
     "node_modules/prettier": {
-<<<<<<< HEAD
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-=======
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -15844,9 +15231,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -15868,15 +15255,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash-x": {
-<<<<<<< HEAD
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.1.1.tgz",
-      "integrity": "sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ==",
-=======
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
       "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16336,11 +15717,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -16351,15 +15735,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-<<<<<<< HEAD
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-=======
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16416,26 +15794,15 @@
       }
     },
     "node_modules/ts-jest": {
-<<<<<<< HEAD
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
       "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
-=======
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
-      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-<<<<<<< HEAD
         "fast-json-stable-stringify": "^2.1.0",
         "handlebars": "^4.7.8",
-=======
-        "ejs": "^3.1.10",
-        "fast-json-stable-stringify": "^2.1.0",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
@@ -16664,15 +16031,9 @@
       }
     },
     "node_modules/typescript": {
-<<<<<<< HEAD
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-=======
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16684,29 +16045,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-<<<<<<< HEAD
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz",
-      "integrity": "sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.40.0.tgz",
+      "integrity": "sha512-Xvd2l+ZmFDPEt4oj1QEXzA4A2uUK6opvKu3eGN9aGjB8au02lIVcLyi375w94hHyejTOmzIU77L8ol2sRg9n7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.39.0",
-        "@typescript-eslint/parser": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0"
-=======
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.38.0.tgz",
-      "integrity": "sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.38.0",
-        "@typescript-eslint/parser": "8.38.0",
-        "@typescript-eslint/typescript-estree": "8.38.0",
-        "@typescript-eslint/utils": "8.38.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
+        "@typescript-eslint/eslint-plugin": "8.40.0",
+        "@typescript-eslint/parser": "8.40.0",
+        "@typescript-eslint/typescript-estree": "8.40.0",
+        "@typescript-eslint/utils": "8.40.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -16717,11 +16065,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
-=======
-        "typescript": ">=4.8.4 <5.9.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/uglify-js": {
@@ -16863,50 +16207,19 @@
       }
     },
     "node_modules/unrs-resolver": {
-<<<<<<< HEAD
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.9.0.tgz",
-      "integrity": "sha512-wqaRu4UnzBD2ABTC1kLfBjAqIDZ5YUTr/MLGa7By47JV1bJDSW7jq/ZSLigB7enLe7ubNaJhtnBXgrc/50cEhg==",
-=======
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
-        "napi-postinstall": "^0.2.2"
-=======
         "napi-postinstall": "^0.3.0"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-<<<<<<< HEAD
-        "@unrs/resolver-binding-android-arm-eabi": "1.9.0",
-        "@unrs/resolver-binding-android-arm64": "1.9.0",
-        "@unrs/resolver-binding-darwin-arm64": "1.9.0",
-        "@unrs/resolver-binding-darwin-x64": "1.9.0",
-        "@unrs/resolver-binding-freebsd-x64": "1.9.0",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.9.0",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.9.0",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.9.0",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.9.0",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.9.0",
-        "@unrs/resolver-binding-linux-x64-musl": "1.9.0",
-        "@unrs/resolver-binding-wasm32-wasi": "1.9.0",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.9.0",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.9.0",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.9.0"
-=======
         "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
         "@unrs/resolver-binding-android-arm64": "1.11.1",
         "@unrs/resolver-binding-darwin-arm64": "1.11.1",
@@ -16926,7 +16239,6 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
->>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/update-browserslist-db": {
@@ -17319,9 +16631,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,11 @@
         "prettier": "^3.3.3",
         "semantic-release": "^24.1.2",
         "ts-jest": "^29.2.5",
+<<<<<<< HEAD
         "typescript": "5.9",
+=======
+        "typescript": "5.8",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "typescript-eslint": "^8.8.0"
       }
     },
@@ -100,14 +104,21 @@
       }
     },
     "node_modules/@babel/core": {
+<<<<<<< HEAD
       "version": "7.27.4",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+=======
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
+<<<<<<< HEAD
         "@babel/generator": "^7.27.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.27.3",
@@ -116,6 +127,16 @@
         "@babel/template": "^7.27.2",
         "@babel/traverse": "^7.27.4",
         "@babel/types": "^7.27.3",
+=======
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -409,14 +430,24 @@
       }
     },
     "node_modules/@babel/helpers": {
+<<<<<<< HEAD
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
       "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+=======
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
+<<<<<<< HEAD
         "@babel/types": "^7.27.6"
+=======
+        "@babel/types": "^7.28.2"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1467,9 +1498,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
+<<<<<<< HEAD
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
       "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
+=======
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1597,6 +1634,7 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
+<<<<<<< HEAD
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
       "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
@@ -1604,6 +1642,15 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
+=======
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "@babel/helper-create-class-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
@@ -1838,9 +1885,15 @@
       }
     },
     "node_modules/@babel/types": {
+<<<<<<< HEAD
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
       "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+=======
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1870,21 +1923,37 @@
       }
     },
     "node_modules/@emnapi/core": {
+<<<<<<< HEAD
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
       "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+=======
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
+<<<<<<< HEAD
         "@emnapi/wasi-threads": "1.0.2",
+=======
+        "@emnapi/wasi-threads": "1.0.4",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
+<<<<<<< HEAD
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
       "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+=======
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1893,9 +1962,15 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
+<<<<<<< HEAD
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
       "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+=======
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2066,9 +2141,15 @@
       }
     },
     "node_modules/@eslint/js": {
+<<<<<<< HEAD
       "version": "9.32.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
       "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+=======
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2743,9 +2824,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
+<<<<<<< HEAD
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+=======
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT"
     },
@@ -2776,16 +2863,26 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
+<<<<<<< HEAD
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
       "integrity": "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==",
+=======
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
+<<<<<<< HEAD
         "@tybys/wasm-util": "^0.9.0"
+=======
+        "@tybys/wasm-util": "^0.10.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2836,9 +2933,15 @@
       }
     },
     "node_modules/@octokit/core": {
+<<<<<<< HEAD
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
       "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
+=======
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
@@ -3022,9 +3125,15 @@
       }
     },
     "node_modules/@octokit/request": {
+<<<<<<< HEAD
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz",
       "integrity": "sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==",
+=======
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^10.1.4",
@@ -3279,9 +3388,15 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/core": {
+<<<<<<< HEAD
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.2.tgz",
       "integrity": "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==",
+=======
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
+      "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3334,9 +3449,15 @@
       "license": "MIT"
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
+<<<<<<< HEAD
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.0.1.tgz",
       "integrity": "sha512-m1KvHlueScy4mQJWvFDCxFBTIdXS0K1SgFGLmqHyX90mZdCIv6gWBbKRhatxRjhGlONuTK/hztYdaqrTXcFZdQ==",
+=======
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
+      "integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3385,9 +3506,15 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/@octokit/request": {
+<<<<<<< HEAD
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.2.tgz",
       "integrity": "sha512-iYj4SJG/2bbhh+iIpFmG5u49DtJ4lipQ+aPakjL9OKpsGY93wM8w06gvFbEQxcMsZcCvk5th5KkIm2m8o14aWA==",
+=======
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+      "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3907,9 +4034,15 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
+<<<<<<< HEAD
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+=======
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4066,9 +4199,15 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
+<<<<<<< HEAD
       "version": "22.17.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
       "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+=======
+      "version": "22.16.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
+      "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4107,17 +4246,30 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
+<<<<<<< HEAD
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
       "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
+=======
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz",
+      "integrity": "sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
+<<<<<<< HEAD
         "@typescript-eslint/scope-manager": "8.39.0",
         "@typescript-eslint/type-utils": "8.39.0",
         "@typescript-eslint/utils": "8.39.0",
         "@typescript-eslint/visitor-keys": "8.39.0",
+=======
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/type-utils": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -4131,6 +4283,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
+<<<<<<< HEAD
         "@typescript-eslint/parser": "^8.39.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
@@ -4147,6 +4300,24 @@
         "@typescript-eslint/types": "8.39.0",
         "@typescript-eslint/typescript-estree": "8.39.0",
         "@typescript-eslint/visitor-keys": "8.39.0",
+=======
+        "@typescript-eslint/parser": "^8.38.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
+      "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4158,6 +4329,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -4170,6 +4342,20 @@
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.39.0",
         "@typescript-eslint/types": "^8.39.0",
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.38.0.tgz",
+      "integrity": "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.38.0",
+        "@typescript-eslint/types": "^8.38.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4180,6 +4366,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -4192,6 +4379,20 @@
       "dependencies": {
         "@typescript-eslint/types": "8.39.0",
         "@typescript-eslint/visitor-keys": "8.39.0"
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.38.0.tgz",
+      "integrity": "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4202,9 +4403,15 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
+<<<<<<< HEAD
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
       "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
+=======
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.38.0.tgz",
+      "integrity": "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4215,6 +4422,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -4228,6 +4436,21 @@
         "@typescript-eslint/types": "8.39.0",
         "@typescript-eslint/typescript-estree": "8.39.0",
         "@typescript-eslint/utils": "8.39.0",
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.38.0.tgz",
+      "integrity": "sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -4240,6 +4463,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -4247,6 +4471,15 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
       "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
+      "integrity": "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4258,6 +4491,7 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
+<<<<<<< HEAD
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
       "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
@@ -4268,6 +4502,18 @@
         "@typescript-eslint/tsconfig-utils": "8.39.0",
         "@typescript-eslint/types": "8.39.0",
         "@typescript-eslint/visitor-keys": "8.39.0",
+=======
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.38.0.tgz",
+      "integrity": "sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.38.0",
+        "@typescript-eslint/tsconfig-utils": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -4283,7 +4529,11 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -4300,16 +4550,28 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
+<<<<<<< HEAD
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
       "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
+=======
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.38.0.tgz",
+      "integrity": "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
+<<<<<<< HEAD
         "@typescript-eslint/scope-manager": "8.39.0",
         "@typescript-eslint/types": "8.39.0",
         "@typescript-eslint/typescript-estree": "8.39.0"
+=======
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4320,6 +4582,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -4331,6 +4594,19 @@
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.39.0",
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.38.0.tgz",
+      "integrity": "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.38.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4355,9 +4631,15 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.9.0.tgz",
       "integrity": "sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm"
       ],
@@ -4369,9 +4651,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.9.0.tgz",
       "integrity": "sha512-sG1NHtgXtX8owEkJ11yn34vt0Xqzi3k9TJ8zppDmyG8GZV4kVWw44FHwKwHeEFl07uKPeC4ZoyuQaGh5ruJYPA==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4383,9 +4671,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.9.0.tgz",
       "integrity": "sha512-nJ9z47kfFnCxN1z/oYZS7HSNsFh43y2asePzTEZpEvK7kGyuShSl3RRXnm/1QaqFL+iP+BjMwuB+DYUymOkA5A==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4397,9 +4691,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.9.0.tgz",
       "integrity": "sha512-TK+UA1TTa0qS53rjWn7cVlEKVGz2B6JYe0C++TdQjvWYIyx83ruwh0wd4LRxYBM5HeuAzXcylA9BH2trARXJTw==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4411,9 +4711,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.9.0.tgz",
       "integrity": "sha512-6uZwzMRFcD7CcCd0vz3Hp+9qIL2jseE/bx3ZjaLwn8t714nYGwiE84WpaMCYjU+IQET8Vu/+BNAGtYD7BG/0yA==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4425,9 +4731,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.9.0.tgz",
       "integrity": "sha512-bPUBksQfrgcfv2+mm+AZinaKq8LCFvt5PThYqRotqSuuZK1TVKkhbVMS/jvSRfYl7jr3AoZLYbDkItxgqMKRkg==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm"
       ],
@@ -4439,9 +4751,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.9.0.tgz",
       "integrity": "sha512-uT6E7UBIrTdCsFQ+y0tQd3g5oudmrS/hds5pbU3h4s2t/1vsGWbbSKhBSCD9mcqaqkBwoqlECpUrRJCmldl8PA==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm"
       ],
@@ -4453,9 +4771,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.9.0.tgz",
       "integrity": "sha512-vdqBh911wc5awE2bX2zx3eflbyv8U9xbE/jVKAm425eRoOVv/VseGZsqi3A3SykckSpF4wSROkbQPvbQFn8EsA==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4467,9 +4791,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.9.0.tgz",
       "integrity": "sha512-/8JFZ/SnuDr1lLEVsxsuVwrsGquTvT51RZGvyDB/dOK3oYK2UqeXzgeyq6Otp8FZXQcEYqJwxb9v+gtdXn03eQ==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4481,9 +4811,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.9.0.tgz",
       "integrity": "sha512-FkJjybtrl+rajTw4loI3L6YqSOpeZfDls4SstL/5lsP2bka9TiHUjgMBjygeZEis1oC8LfJTS8FSgpKPaQx2tQ==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "ppc64"
       ],
@@ -4495,9 +4831,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.9.0.tgz",
       "integrity": "sha512-w/NZfHNeDusbqSZ8r/hp8iL4S39h4+vQMc9/vvzuIKMWKppyUGKm3IST0Qv0aOZ1rzIbl9SrDeIqK86ZpUK37w==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "riscv64"
       ],
@@ -4509,9 +4851,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.9.0.tgz",
       "integrity": "sha512-bEPBosut8/8KQbUixPry8zg/fOzVOWyvwzOfz0C0Rw6dp+wIBseyiHKjkcSyZKv/98edrbMknBaMNJfA/UEdqw==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "riscv64"
       ],
@@ -4523,9 +4871,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.9.0.tgz",
       "integrity": "sha512-LDtMT7moE3gK753gG4pc31AAqGUC86j3AplaFusc717EUGF9ZFJ356sdQzzZzkBk1XzMdxFyZ4f/i35NKM/lFA==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "s390x"
       ],
@@ -4537,9 +4891,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.9.0.tgz",
       "integrity": "sha512-WmFd5KINHIXj8o1mPaT8QRjA9HgSXhN1gl9Da4IZihARihEnOylu4co7i/yeaIpcfsI6sYs33cNZKyHYDh0lrA==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4551,9 +4911,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.9.0.tgz",
       "integrity": "sha512-CYuXbANW+WgzVRIl8/QvZmDaZxrqvOldOwlbUjIM4pQ46FJ0W5cinJ/Ghwa/Ng1ZPMJMk1VFdsD/XwmCGIXBWg==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4565,9 +4931,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.9.0.tgz",
       "integrity": "sha512-6Rp2WH0OoitMYR57Z6VE8Y6corX8C6QEMWLgOV6qXiJIeZ1F9WGXY/yQ8yDC4iTraotyLOeJ2Asea0urWj2fKQ==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "wasm32"
       ],
@@ -4582,9 +4954,15 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.9.0.tgz",
       "integrity": "sha512-rknkrTRuvujprrbPmGeHi8wYWxmNVlBoNW8+4XF2hXUnASOjmuC9FNF1tGbDiRQWn264q9U/oGtixyO3BT8adQ==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "arm64"
       ],
@@ -4596,9 +4974,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.9.0.tgz",
       "integrity": "sha512-Ceymm+iBl+bgAICtgiHyMLz6hjxmLJKqBim8tDzpX61wpZOx2bPK6Gjuor7I2RiUynVjvvkoRIkrPyMwzBzF3A==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "ia32"
       ],
@@ -4610,9 +4994,15 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.0.tgz",
       "integrity": "sha512-k59o9ZyeyS0hAlcaKFezYSH2agQeRFEB7KoQLXl3Nb3rgkqT1NY9Vwy+SqODiLmYnEjxWJVRE/yq2jFVqdIxZw==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "cpu": [
         "x64"
       ],
@@ -4647,9 +5037,15 @@
       }
     },
     "node_modules/agent-base": {
+<<<<<<< HEAD
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+=======
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4891,6 +5287,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5134,9 +5540,15 @@
       }
     },
     "node_modules/browserslist": {
+<<<<<<< HEAD
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
       "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+=======
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "funding": [
         {
@@ -5154,8 +5566,13 @@
       ],
       "license": "MIT",
       "dependencies": {
+<<<<<<< HEAD
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
+=======
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -5267,9 +5684,15 @@
       }
     },
     "node_modules/caniuse-lite": {
+<<<<<<< HEAD
       "version": "1.0.30001723",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
       "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
+=======
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "funding": [
         {
@@ -5676,9 +6099,15 @@
       }
     },
     "node_modules/conventional-changelog-writer": {
+<<<<<<< HEAD
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.1.0.tgz",
       "integrity": "sha512-dpC440QnORNCO81XYuRRFOLCsjKj4W7tMkUIn3lR6F/FAaJcWLi7iCj6IcEvSQY2zw6VUgwUKd5DEHKEWrpmEQ==",
+=======
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
+      "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5754,6 +6183,7 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
+<<<<<<< HEAD
       "version": "3.43.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
       "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
@@ -5761,6 +6191,15 @@
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.25.0"
+=======
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
+      "integrity": "sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.25.1"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "funding": {
         "type": "opencollective",
@@ -6144,10 +6583,33 @@
         "readable-stream": "^2.0.2"
       }
     },
+<<<<<<< HEAD
     "node_modules/electron-to-chromium": {
       "version": "1.5.167",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
       "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
+=======
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.191",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
+      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "ISC"
     },
@@ -6572,9 +7034,15 @@
       }
     },
     "node_modules/eslint": {
+<<<<<<< HEAD
       "version": "9.32.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+=======
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6584,8 +7052,13 @@
         "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
+<<<<<<< HEAD
         "@eslint/js": "9.32.0",
         "@eslint/plugin-kit": "^0.3.4",
+=======
+        "@eslint/js": "9.31.0",
+        "@eslint/plugin-kit": "^0.3.1",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -6649,14 +7122,24 @@
       }
     },
     "node_modules/eslint-import-context": {
+<<<<<<< HEAD
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.8.tgz",
       "integrity": "sha512-bq+F7nyc65sKpZGT09dY0S0QrOnQtuDVIfyTGQ8uuvtMIF7oHp6CEP3mouN0rrnYF3Jqo6Ke0BfU/5wASZue1w==",
+=======
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-tsconfig": "^4.10.1",
+<<<<<<< HEAD
         "stable-hash-x": "^0.1.1"
+=======
+        "stable-hash-x": "^0.2.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -6730,6 +7213,7 @@
         }
       }
     },
+<<<<<<< HEAD
     "node_modules/eslint-import-resolver-typescript/node_modules/stable-hash-x": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -6740,6 +7224,8 @@
         "node": ">=12.0.0"
       }
     },
+=======
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
@@ -7324,6 +7810,32 @@
         "node": ">=16.0.0"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8800,6 +9312,85 @@
         "node": ">=8"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/jake": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
     "node_modules/java-properties": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -10406,9 +10997,15 @@
       }
     },
     "node_modules/napi-postinstall": {
+<<<<<<< HEAD
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
       "integrity": "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==",
+=======
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
+      "integrity": "sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -13892,9 +14489,15 @@
       }
     },
     "node_modules/prettier": {
+<<<<<<< HEAD
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+=======
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -15265,9 +15868,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash-x": {
+<<<<<<< HEAD
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.1.1.tgz",
       "integrity": "sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ==",
+=======
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15742,9 +16351,15 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
+<<<<<<< HEAD
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+=======
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15801,15 +16416,26 @@
       }
     },
     "node_modules/ts-jest": {
+<<<<<<< HEAD
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
       "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+=======
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
+<<<<<<< HEAD
         "fast-json-stable-stringify": "^2.1.0",
         "handlebars": "^4.7.8",
+=======
+        "ejs": "^3.1.10",
+        "fast-json-stable-stringify": "^2.1.0",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
@@ -16038,9 +16664,15 @@
       }
     },
     "node_modules/typescript": {
+<<<<<<< HEAD
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+=======
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16052,6 +16684,7 @@
       }
     },
     "node_modules/typescript-eslint": {
+<<<<<<< HEAD
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz",
       "integrity": "sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==",
@@ -16062,6 +16695,18 @@
         "@typescript-eslint/parser": "8.39.0",
         "@typescript-eslint/typescript-estree": "8.39.0",
         "@typescript-eslint/utils": "8.39.0"
+=======
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.38.0.tgz",
+      "integrity": "sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.38.0",
+        "@typescript-eslint/parser": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -16072,7 +16717,11 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
+<<<<<<< HEAD
         "typescript": ">=4.8.4 <6.0.0"
+=======
+        "typescript": ">=4.8.4 <5.9.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/uglify-js": {
@@ -16214,19 +16863,30 @@
       }
     },
     "node_modules/unrs-resolver": {
+<<<<<<< HEAD
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.9.0.tgz",
       "integrity": "sha512-wqaRu4UnzBD2ABTC1kLfBjAqIDZ5YUTr/MLGa7By47JV1bJDSW7jq/ZSLigB7enLe7ubNaJhtnBXgrc/50cEhg==",
+=======
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+<<<<<<< HEAD
         "napi-postinstall": "^0.2.2"
+=======
+        "napi-postinstall": "^0.3.0"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
+<<<<<<< HEAD
         "@unrs/resolver-binding-android-arm-eabi": "1.9.0",
         "@unrs/resolver-binding-android-arm64": "1.9.0",
         "@unrs/resolver-binding-darwin-arm64": "1.9.0",
@@ -16246,6 +16906,27 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.9.0",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.9.0",
         "@unrs/resolver-binding-win32-x64-msvc": "1.9.0"
+=======
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+>>>>>>> 42fa5ca (fix(env-vars): SHEPHERD_BASE_BRANCH var fix)
       }
     },
     "node_modules/update-browserslist-db": {

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -288,4 +288,50 @@ describe('GithubAdapter', () => {
       );
     });
   });
+
+  describe('getBaseBranch', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterAll(() => {
+      process.env = originalEnv;
+    });
+
+    it('returns the repo defaultBranch when SHEPHERD_BASE_BRANCH is not set', () => {
+      const mocktokit = {} as any as Octokit;
+      const context = mockMigrationContext();
+      const service = new GithubService(context, mocktokit);
+      const adapter = new GithubAdapter(context, service);
+      const repo = { owner: 'NerdWallet', name: 'shepherd', defaultBranch: 'main' };
+      delete process.env.SHEPHERD_BASE_BRANCH;
+
+      expect(adapter.getBaseBranch(repo)).toBe('main');
+    });
+
+    it('returns the environment variable value when SHEPHERD_BASE_BRANCH is set', () => {
+      const mocktokit = {} as any as Octokit;
+      const context = mockMigrationContext();
+      const service = new GithubService(context, mocktokit);
+      const adapter = new GithubAdapter(context, service);
+      const repo = { owner: 'NerdWallet', name: 'shepherd', defaultBranch: 'main' };
+      process.env.SHEPHERD_BASE_BRANCH = 'develop';
+
+      expect(adapter.getBaseBranch(repo)).toBe('develop');
+    });
+
+    it('returns an empty string when SHEPHERD_BASE_BRANCH is an empty string', () => {
+      const mocktokit = {} as any as Octokit;
+      const context = mockMigrationContext();
+      const service = new GithubService(context, mocktokit);
+      const adapter = new GithubAdapter(context, service);
+      const repo = { owner: 'NerdWallet', name: 'shepherd', defaultBranch: 'main' };
+      process.env.SHEPHERD_BASE_BRANCH = '';
+
+      expect(adapter.getBaseBranch(repo)).toBe('');
+    });
+  });
 });

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -256,32 +256,6 @@ describe('GithubAdapter', () => {
     });
   });
 
-  describe('getBaseBranch', () => {
-    const context = mockMigrationContext();
-    const mocktokit = {} as any as Octokit;
-    const service = new GithubService(context, mocktokit);
-    const adapter = new GithubAdapter(context, service);
-    const repo = { owner: 'NerdWallet', name: 'shepherd', defaultBranch: 'main' };
-
-    afterEach(() => {
-      delete process.env.SHEPHERD_BASE_BRANCH;
-    });
-
-    it('returns SHEPHERD_BASE_BRANCH env var if set', () => {
-      process.env.SHEPHERD_BASE_BRANCH = 'feature-branch';
-      expect(adapter.getBaseBranch(repo)).toBe('feature-branch');
-    });
-
-    it('trims SHEPHERD_BASE_BRANCH env var', () => {
-      process.env.SHEPHERD_BASE_BRANCH = '  develop  ';
-      expect(adapter.getBaseBranch(repo)).toBe('develop');
-    });
-
-    it('returns repo.defaultBranch if SHEPHERD_BASE_BRANCH is not set', () => {
-      expect(adapter.getBaseBranch(repo)).toBe('main');
-    });
-  });
-
   describe('getRepositoryUrl', () => {
     const context = mockMigrationContext();
     const octokit = {} as any as Octokit;

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -256,6 +256,32 @@ describe('GithubAdapter', () => {
     });
   });
 
+  describe('getBaseBranch', () => {
+    const context = mockMigrationContext();
+    const mocktokit = {} as any as Octokit;
+    const service = new GithubService(context, mocktokit);
+    const adapter = new GithubAdapter(context, service);
+    const repo = { owner: 'NerdWallet', name: 'shepherd', defaultBranch: 'main' };
+
+    afterEach(() => {
+      delete process.env.SHEPHERD_BASE_BRANCH;
+    });
+
+    it('returns SHEPHERD_BASE_BRANCH env var if set', () => {
+      process.env.SHEPHERD_BASE_BRANCH = 'feature-branch';
+      expect(adapter.getBaseBranch(repo)).toBe('feature-branch');
+    });
+
+    it('trims SHEPHERD_BASE_BRANCH env var', () => {
+      process.env.SHEPHERD_BASE_BRANCH = '  develop  ';
+      expect(adapter.getBaseBranch(repo)).toBe('develop');
+    });
+
+    it('returns repo.defaultBranch if SHEPHERD_BASE_BRANCH is not set', () => {
+      expect(adapter.getBaseBranch(repo)).toBe('main');
+    });
+  });
+
   describe('getRepositoryUrl', () => {
     const context = mockMigrationContext();
     const octokit = {} as any as Octokit;
@@ -265,6 +291,14 @@ describe('GithubAdapter', () => {
       owner: 'NerdWallet',
       name: 'shepherd',
     };
+
+    beforeAll(() => {
+      process.env.SHEPHERD_GITHUB_ENTERPRISE_BASE_URL = 'github.com';
+    });
+
+    afterAll(() => {
+      delete process.env.SHEPHERD_GITHUB_ENTERPRISE_BASE_URL;
+    });
 
     it('returns the SSH URL, when not given a protocol', () => {
       delete process.env.SHEPHERD_GITHUB_PROTOCOL;

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -290,7 +290,7 @@ class GithubAdapter extends GitAdapter {
   }
 
   public getBaseBranch(repo: IRepo): string {
-    return repo.defaultBranch;
+    return process.env.SHEPHERD_BASE_BRANCH ?? repo.defaultBranch;
   }
 
   public async getEnvironmentVariables(repo: IRepo): Promise<IEnvironmentVariables> {


### PR DESCRIPTION
This pull request introduces a new feature to the `GithubAdapter` class that allows the base branch to be determined dynamically based on an environment variable. It also includes corresponding unit tests to ensure the new behavior works as intended.

### Feature Enhancement:

* [`src/adapters/github.ts`](diffhunk://#diff-275c76f8995ad367ffe7a0c7f165d04a769a1e094ccf05a3b053ee1f71e2aa5bL293-R293): Updated the `getBaseBranch` method to check for the `SHEPHERD_BASE_BRANCH` environment variable. If it is set, the method returns its value; otherwise, it falls back to the repository's default branch (`repo.defaultBranch`).

### Testing:

* `src/adapters/github.test.ts`: Added a new test suite for the `getBaseBranch` method. This includes tests for scenarios where:
  - The `SHEPHERD_BASE_BRANCH` environment variable is not set, and the method defaults to the repository's default branch.
  - The `SHEPHERD_BASE_BRANCH` environment variable is set, and the method returns its value.
  - The `SHEPHERD_BASE_BRANCH` environment variable is an empty string, and the method returns an empty string.